### PR TITLE
feat: ignore future executables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Ignore all executables
-cmd/*
-cmd/!*.*
-cmd/!*/
+/cmd/*
+!/cmd/*.*
+!/cmd/*/
 
 # Created by .ignore support plugin (hsz.mobi)
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Ignore all executables
+cmd/*
+cmd/!*.*
+cmd/!*/
+
 # Created by .ignore support plugin (hsz.mobi)
 
 .DS_Store


### PR DESCRIPTION
## Description

Currently, there is no check for added executables and they clutter the repo by including files from the build. This PR adds new lines to the `.gitignore` file to only include files with type extension or folders.

## Linked PRs
- #28 included lukso executable