### PR TITLE
fix: Add additional step to also deploy to google bucket.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,8 @@ on:
       - '*'
 
 permissions:
-  id-token: 'write'
+  id-token: write
+  pull-requests: write
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,10 @@ on:
       - main
   pull_request:
     branches:
-      - main
+      - '*'
+
+permissions:
+  id-token: 'write'
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -362,12 +362,10 @@ jobs:
         if: ${{ needs.release_please.outputs.release_created != 'true' }}
         run: |
           mkdir -p dist
-          rm -rf dist/artifacts
-          mkdir -p dist/artifacts
-          find artifacts -type f -exec cp {} dist/artifacts \;
+          # Remove artifacts inside of PR reviews and point to the ones inside of the google bucket.
+          # This fixes the repo size and prepares for the proxy switch early.
           sed \
-            -e 's#https://github.com/lukso-network/tools-lukso-cli/releases#https://lukso-network.github.io/tools-lukso-cli/pr-preview/pr-${{ github.event.number }}#g' \
-            -e 's#${BASE_URL}/latest/download#${BASE_URL}/artifacts#g' \
+            -e 's#https://storage.googleapis.com/lks-lz-binaries-euw4#https://storage.googleapis.com/lks-lz-binaries-euw4/${{ github.event.number }}#g' \
             -e 's#__VERSION__#${{ needs.release_please.outputs.version_name }}#g' \
             install/install.sh > dist/index.html
       - name: Deploy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 permissions:
   id-token: write
   pull-requests: write
-  contents: read
+  contents: write
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -337,8 +337,7 @@ jobs:
         if: ${{ needs.release_please.outputs.release_created != 'true' }}
         run: |
           mkdir -p bucket
-          rm -rf bucket/artifacts
-          mkdir -p bucket/artifacts
+          rm -rf bucket/artifacts && mkdir -p bucket/artifacts
           find artifacts -type f -exec cp {} bucket/artifacts \;
           sed \
             -e 's#https://storage.googleapis.com/lks-lz-binaries-euw4#https://storage.googleapis.com/lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}#g' \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   id-token: write
   pull-requests: write
+  contents: read
 
 env:
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
       - main
   pull_request:
     branches:
-      - '*'
+      - "*"
 
 permissions:
   id-token: write
@@ -352,19 +352,19 @@ jobs:
           create_credentials_file: "true"
           workload_identity_provider: "projects/311968610280/locations/global/workloadIdentityPools/github/providers/github"
           service_account: "artifact-deployer@lks-lz-management.iam.gserviceaccount.com"
-      
+
       - name: Copy files
         run: |-
           gcloud auth login --brief --cred-file="${{ steps.gcpauth.outputs.credentials_file_path }}"
           echo "gsutil -m cp -r ./bucket/* gs://lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}/"
           gsutil -m cp -r ./bucket/* gs://lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}/
-      
+
       - name: Add PR status
         if: ${{ needs.release_please.outputs.release_created != 'true' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pr-install
-          message: :rocket: Deployed preview to `curl https://storage.googleapis.com/lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}/install.sh | sh`
+          message: ":rocket: Deployed preview to `curl https://storage.googleapis.com/lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}/install.sh | sh`"
 
       # OLD CODE TO DEPLOY TO GH_PAGES
       - name: Copy script

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -352,10 +352,12 @@ jobs:
           create_credentials_file: "true"
           workload_identity_provider: "projects/311968610280/locations/global/workloadIdentityPools/github/providers/github"
           service_account: "artifact-deployer@lks-lz-management.iam.gserviceaccount.com"
+      
       - name: Copy files
         run: |-
           gcloud auth login --brief --cred-file="${{ steps.gcpauth.outputs.credentials_file_path }}"
-          gsutil cp -r ./bucket/* gs://lks-lz-binaries-euw4/${{ needs.release_please.outputs.folder }}
+          echo "gsutil -m cp -r ./bucket/* gs://lks-lz-binaries-euw4/${{ needs.release_please.outputs.folder }}/"
+          gsutil -m cp -r ./bucket/* gs://lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}/
 
       # OLD CODE TO DEPLOY TO GH_PAGES
       - name: Copy script

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -358,6 +358,13 @@ jobs:
           gcloud auth login --brief --cred-file="${{ steps.gcpauth.outputs.credentials_file_path }}"
           echo "gsutil -m cp -r ./bucket/* gs://lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}/"
           gsutil -m cp -r ./bucket/* gs://lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}/
+      
+      - name: Add PR status
+        if: ${{ needs.release_please.outputs.release_created != 'true' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-install
+          message: :rocket: Deployed preview to `curl https://storage.googleapis.com/lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}/install.sh | sh`
 
       # OLD CODE TO DEPLOY TO GH_PAGES
       - name: Copy script

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -338,7 +338,7 @@ jobs:
           sed \
             -e 's#https://storage.googleapis.com/lks-lz-binaries-euw4#https://storage.googleapis.com/lks-lz-binaries-euw4/${{ github.event.number }}#g' \
             -e 's#__VERSION__#${{ needs.release_please.outputs.version_name }}#g' \
-            install/install.sh > dist/index.html
+            install/install.sh > bucket/install.sh
 
       - name: Authenticate to Google Cloud
         id: gcpauth

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
       - main
   pull_request:
     branches:
-      - "*"
+      - main
 
 env:
   CARGO_INCREMENTAL: 0
@@ -24,6 +24,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       version_name: ${{ steps.calc.outputs.version }}
+      folder: ${{ steps.calc.output.folder }}
     steps:
       - name: Validate | Checkout
         uses: actions/checkout@v3
@@ -42,16 +43,20 @@ jobs:
             SHA="${{ github.sha }}"
             # For the extension we cannot use - but must use . for the PR number.
             VERSION="v$(node -pe 'require("./.release-please-manifest.json")["."]')+${SHA:0:7}"
+            FOLDER=''
             if [ -n "${{ github.event.number }}" ]
             then
               VERSION="${VERSION}+pr-${{ github.event.number }}"
+              FOLDER="/${{ github.event.number }}"
             else
               VERSION="${VERSION}+${{ github.ref }}"
+              FOLDER="/preview"
             fi
           else
             VERSION="${{ steps.release.outputs.tag_name }}"
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "folder=$FOLDER" >> $GITHUB_OUTPUT
 
   check_test:
     runs-on: ubuntu-latest
@@ -234,7 +239,7 @@ jobs:
           cd install/docs-processor
           yarn
           node ./convert.js --in ../../docs --out ../../public
-      
+
       - name: Update pkg docs
         run: |
           cp -r ./public/* ./install/macos_packages/pkg_resources/English.lproj/
@@ -312,16 +317,47 @@ jobs:
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v3
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        if: ${{ needs.release_please.outputs.release_created != 'true' }}
+        with:
+          path: artifacts
+
+      - name: Copy script - bucket
+        if: ${{ needs.release_please.outputs.release_created == 'true' }}
+        run: |
+          mkdir -p bucket
+          sed -e "s#__VERSION__#${{ needs.release_please.outputs.version_name }}" install/install.sh > bucket/install.sh
+      - name: Copy PR scripts - bucket
+        if: ${{ needs.release_please.outputs.release_created != 'true' }}
+        run: |
+          mkdir -p bucket
+          rm -rf bucket/artifacts
+          mkdir -p bucket/artifacts
+          find artifacts -type f -exec cp {} bucket/artifacts \;
+          sed \
+            -e 's#https://storage.googleapis.com/lks-lz-binaries-euw4#https://storage.googleapis.com/lks-lz-binaries-euw4/${{ github.event.number }}#g' \
+            -e 's#__VERSION__#${{ needs.release_please.outputs.version_name }}#g' \
+            install/install.sh > dist/index.html
+
+      - name: Authenticate to Google Cloud
+        id: gcpauth
+        uses: google-github-actions/auth@v1
+        with:
+          create_credentials_file: "true"
+          workload_identity_provider: "projects/311968610280/locations/global/workloadIdentityPools/github/providers/github"
+          service_account: "artifact-deployer@lks-lz-management.iam.gserviceaccount.com"
+      - name: Copy files
+        run: |-
+          gcloud auth login --brief --cred-file="${{ steps.gcpauth.outputs.credentials_file_path }}"
+          gsutil cp ./bucket/* gs://lks-lz-binaries-euw4/${{ needs.release_please.outputs.folder }}
+
+      # OLD CODE TO DEPLOY TO GH_PAGES
       - name: Copy script
         if: ${{ needs.release_please.outputs.release_created == 'true' }}
         run: |
           mkdir -p dist
           sed -e "s#__VERSION__#${{ needs.release_please.outputs.version_name }}" install/install.sh > dist/index.html
-      - name: Notarize | Download artifacts
-        uses: actions/download-artifact@v3
-        if: ${{ needs.release_please.outputs.release_created != 'true' }}
-        with:
-          path: artifacts
       - name: Copy PR scripts
         if: ${{ needs.release_please.outputs.release_created != 'true' }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -316,24 +316,25 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
   publish_docs:
-    name: Publish script
+    name: Publish install script
     needs: [notarize_and_pkgbuild, release_please]
     runs-on: ubuntu-latest
     steps:
-      - name: Setup | Checkout
+      - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Download artifacts
+      - name: Download build artifacts
         uses: actions/download-artifact@v3
         if: ${{ needs.release_please.outputs.release_created != 'true' }}
         with:
           path: artifacts
 
-      - name: Copy script - bucket
+      - name: Prepare install.sh with version=${{ needs.release_please.outputs.version_name }}
         if: ${{ needs.release_please.outputs.release_created == 'true' }}
         run: |
           mkdir -p bucket
           sed -e "s#__VERSION__#${{ needs.release_please.outputs.version_name }}" install/install.sh > bucket/install.sh
-      - name: Copy PR scripts - bucket
+
+      - name: Prepare install.sh and artifacts with version=${{ needs.release_please.outputs.version_name }} and URL=https://storage.googleapis.com/lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}
         if: ${{ needs.release_please.outputs.release_created != 'true' }}
         run: |
           mkdir -p bucket
@@ -352,13 +353,12 @@ jobs:
           workload_identity_provider: "projects/311968610280/locations/global/workloadIdentityPools/github/providers/github"
           service_account: "artifact-deployer@lks-lz-management.iam.gserviceaccount.com"
 
-      - name: Copy files
+      - name: Copying script and artifacts to gs://lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}/
         run: |-
           gcloud auth login --brief --cred-file="${{ steps.gcpauth.outputs.credentials_file_path }}"
-          echo "gsutil -m cp -r ./bucket/* gs://lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}/"
           gsutil -m cp -r ./bucket/* gs://lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}/
 
-      - name: Add PR status
+      - name: Add PR status for ${{ github.event.number }} (curl without proxy from https://storage.googleapis.com/lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}/install.sh)
         if: ${{ needs.release_please.outputs.release_created != 'true' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
@@ -366,12 +366,13 @@ jobs:
           message: ":rocket: Deployed preview to `curl https://storage.googleapis.com/lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}/install.sh | sh`"
 
       # OLD CODE TO DEPLOY TO GH_PAGES
-      - name: Copy script
+      - name: Processing script to add version ${{ needs.release_please.outputs.version_name }}
         if: ${{ needs.release_please.outputs.release_created == 'true' }}
         run: |
           mkdir -p dist
           sed -e "s#__VERSION__#${{ needs.release_please.outputs.version_name }}" install/install.sh > dist/index.html
-      - name: Copy PR scripts
+
+      - name: Processing script to add version ${{ needs.release_please.outputs.version_name }} and URL https://storage.googleapis.com/lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}
         if: ${{ needs.release_please.outputs.release_created != 'true' }}
         run: |
           mkdir -p dist
@@ -381,13 +382,15 @@ jobs:
             -e 's#https://storage.googleapis.com/lks-lz-binaries-euw4#https://storage.googleapis.com/lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}#g' \
             -e 's#__VERSION__#${{ needs.release_please.outputs.version_name }}#g' \
             install/install.sh > dist/index.html
-      - name: Deploy
+
+      - name: Deploy to Github pages
         uses: JamesIves/github-pages-deploy-action@v4
         if: ${{ needs.release_please.outputs.release_created == 'true' }}
         with:
           folder: ./dist
           clean-exclude: pr-preview/
-      - name: Deploy PR
+
+      - name: Deploy PR to Github pages
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -355,7 +355,7 @@ jobs:
       - name: Copy files
         run: |-
           gcloud auth login --brief --cred-file="${{ steps.gcpauth.outputs.credentials_file_path }}"
-          gsutil cp -rf ./bucket/* gs://lks-lz-binaries-euw4/${{ needs.release_please.outputs.folder }}
+          gsutil cp -r ./bucket/* gs://lks-lz-binaries-euw4/${{ needs.release_please.outputs.folder }}
 
       # OLD CODE TO DEPLOY TO GH_PAGES
       - name: Copy script

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       version_name: ${{ steps.calc.outputs.version }}
-      folder: ${{ steps.calc.output.folder }}
+      folder: ${{ steps.calc.outputs.folder }}
     steps:
       - name: Validate | Checkout
         uses: actions/checkout@v3
@@ -43,12 +43,12 @@ jobs:
       - id: calc
         name: Detect final version name
         run: |
+          FOLDER=''
           if [ "${{ steps.release.outputs.release_created }}" != "true" ]
           then
             SHA="${{ github.sha }}"
             # For the extension we cannot use - but must use . for the PR number.
             VERSION="v$(node -pe 'require("./.release-please-manifest.json")["."]')+${SHA:0:7}"
-            FOLDER=''
             if [ -n "${{ github.event.number }}" ]
             then
               VERSION="${VERSION}+pr-${{ github.event.number }}"
@@ -341,7 +341,7 @@ jobs:
           mkdir -p bucket/artifacts
           find artifacts -type f -exec cp {} bucket/artifacts \;
           sed \
-            -e 's#https://storage.googleapis.com/lks-lz-binaries-euw4#https://storage.googleapis.com/lks-lz-binaries-euw4/${{ github.event.number }}#g' \
+            -e 's#https://storage.googleapis.com/lks-lz-binaries-euw4#https://storage.googleapis.com/lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}#g' \
             -e 's#__VERSION__#${{ needs.release_please.outputs.version_name }}#g' \
             install/install.sh > bucket/install.sh
 
@@ -356,7 +356,7 @@ jobs:
       - name: Copy files
         run: |-
           gcloud auth login --brief --cred-file="${{ steps.gcpauth.outputs.credentials_file_path }}"
-          echo "gsutil -m cp -r ./bucket/* gs://lks-lz-binaries-euw4/${{ needs.release_please.outputs.folder }}/"
+          echo "gsutil -m cp -r ./bucket/* gs://lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}/"
           gsutil -m cp -r ./bucket/* gs://lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}/
 
       # OLD CODE TO DEPLOY TO GH_PAGES
@@ -372,7 +372,7 @@ jobs:
           # Remove artifacts inside of PR reviews and point to the ones inside of the google bucket.
           # This fixes the repo size and prepares for the proxy switch early.
           sed \
-            -e 's#https://storage.googleapis.com/lks-lz-binaries-euw4#https://storage.googleapis.com/lks-lz-binaries-euw4/${{ github.event.number }}#g' \
+            -e 's#https://storage.googleapis.com/lks-lz-binaries-euw4#https://storage.googleapis.com/lks-lz-binaries-euw4${{ needs.release_please.outputs.folder }}#g' \
             -e 's#__VERSION__#${{ needs.release_please.outputs.version_name }}#g' \
             install/install.sh > dist/index.html
       - name: Deploy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -355,7 +355,7 @@ jobs:
       - name: Copy files
         run: |-
           gcloud auth login --brief --cred-file="${{ steps.gcpauth.outputs.credentials_file_path }}"
-          gsutil cp ./bucket/* gs://lks-lz-binaries-euw4/${{ needs.release_please.outputs.folder }}
+          gsutil cp -rf ./bucket/* gs://lks-lz-binaries-euw4/${{ needs.release_please.outputs.folder }}
 
       # OLD CODE TO DEPLOY TO GH_PAGES
       - name: Copy script

--- a/.github/workflows/remove.yml
+++ b/.github/workflows/remove.yml
@@ -1,5 +1,3 @@
-github.event.pull_request.merged == true
-
 name: Remove
 on:
   pull_request:

--- a/.github/workflows/remove.yml
+++ b/.github/workflows/remove.yml
@@ -1,0 +1,34 @@
+github.event.pull_request.merged == true
+
+name: Remove
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  publish_docs:
+    name: Publish script
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate to Google Cloud
+        id: gcpauth
+        uses: google-github-actions/auth@v1
+        with:
+          create_credentials_file: "true"
+          workload_identity_provider: "projects/311968610280/locations/global/workloadIdentityPools/github/providers/github"
+          service_account: "artifact-deployer@lks-lz-management.iam.gserviceaccount.com"
+      - name: Copy files
+        run: |-
+          gcloud auth login --brief --cred-file="${{ steps.gcpauth.outputs.credentials_file_path }}"
+          gsutil rm -r -f ./bucket/${{ github.event.number }}/*
+      
+      # NEW CODE TO CLEANUP OLD GH_PAGES
+      - name: Create dir
+        run: mkdir -p ./dist
+      - name: Deploy PR
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./dist

--- a/.github/workflows/remove.yml
+++ b/.github/workflows/remove.yml
@@ -6,6 +6,10 @@ on:
     types:
       - closed
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   publish_docs:
     name: Publish script
@@ -22,7 +26,7 @@ jobs:
         run: |-
           gcloud auth login --brief --cred-file="${{ steps.gcpauth.outputs.credentials_file_path }}"
           gsutil -m rm -r -f ./bucket/${{ github.event.number }}/*
-      
+
       # NEW CODE TO CLEANUP OLD GH_PAGES
       - name: Create dir
         run: mkdir -p ./dist

--- a/.github/workflows/remove.yml
+++ b/.github/workflows/remove.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Copy files
         run: |-
           gcloud auth login --brief --cred-file="${{ steps.gcpauth.outputs.credentials_file_path }}"
-          gsutil rm -r -f ./bucket/${{ github.event.number }}/*
+          gsutil -m rm -r -f ./bucket/${{ github.event.number }}/*
       
       # NEW CODE TO CLEANUP OLD GH_PAGES
       - name: Create dir

--- a/install/cf-wrangler/src/index.js
+++ b/install/cf-wrangler/src/index.js
@@ -11,12 +11,7 @@ export default {
     const match = /^\/?(l?\d*)?\/?$/.exec(url.pathname);
     if (match) {
       const pr = match[1];
-      url.pathname = pr
-        ? `/tools-lukso-cli/pr-preview/pr-${pr}/index.html`
-        : `/tools-lukso-cli/index.html`;
-      url.hostname = "lukso-network.github.io";
-      const fetchUrl = url.toString();
-      const proxyRequest = await fetch(fetchUrl);
+      const proxyRequest = await fetch(`https://storage.googleapis.com/lks-lz-binaries-euw4${pr ? `/${pr}/install.sh` : '/install.sh'}`);
       if (proxyRequest.status !== 200) {
         return new Response(proxyRequest.statusTest, {
           status: proxyRequest.status,

--- a/install/install.sh
+++ b/install/install.sh
@@ -250,7 +250,7 @@ confirm() {
       exit 1
     fi
     if [ "$yn" != "y" ] && [ "$yn" != "yes" ]; then
-      error 'Aborting (please answer "yes" to continue)'
+      error 'Aborting installation'
       exit 1
     fi
   fi
@@ -329,7 +329,7 @@ if [ -z "${ARCH-}" ]; then
 fi
 
 if [ -z "${BASE_URL-}" ]; then
-  BASE_URL="https://github.com/lukso-network/tools-lukso-cli/releases"
+  BASE_URL="https://storage.googleapis.com/lks-lz-binaries-euw4"
 fi
 
 # Non-POSIX shells can break once executing code due to semantic differences
@@ -409,9 +409,9 @@ if WHERE=$(which lukso)
 then
   WHERE=$(dirname "${WHERE}")
   PREVIOUS=""
-  if ! PREVIOUS=$(lukso version)
+  if ! PREVIOUS=$(lukso version 2> /dev/null)
   then
-    if PREVIOUS=$(lukso -v)
+    if PREVIOUS=$(lukso -v 2> /dev/null)
     then
       PREVIOUS="${PREVIOUS} (deprecated)"
     else
@@ -421,6 +421,15 @@ then
   PREVIOUS=$(echo "${PREVIOUS}" | sed -n -e "s#.*\(v[0-9][0-9]*\..*\)\$#\1#p" -e "s#.*\(develop\)\$#\1#p")
   if [ -n "${PREVIOUS}" ]
   then
+    if [ "${PREVIOUS}" == "__VERSION__" ]
+    then
+      printf "  %s\n" "${UNDERLINE}${GREEN}You currently have the current version installed${NO_COLOR}"
+      info "${BOLD}Current bin${NO_COLOR}:      ${GREEN}${WHERE}${NO_COLOR}"
+      info "${BOLD}Current version${NO_COLOR}:  ${GREEN}${PREVIOUS}${NO_COLOR}"
+      info "${BOLD}Platform${NO_COLOR}:         ${GREEN}${PLATFORM}${NO_COLOR}"
+      info "${BOLD}Arch${NO_COLOR}:             ${GREEN}${ARCH}${NO_COLOR}"
+      exit
+    fi
     printf "  %s\n" "${UNDERLINE}You currently have a previous version installed${NO_COLOR}"
     info "${BOLD}Current bin${NO_COLOR}:      ${GREEN}${WHERE}${NO_COLOR}"
     info "${BOLD}Current version${NO_COLOR}:  ${GREEN}${PREVIOUS}${NO_COLOR}"
@@ -455,7 +464,7 @@ printf '\n'
 
 EXT=tar.gz
 
-URL="${BASE_URL}/latest/download/lukso-${TARGET}.${EXT}"
+URL="${BASE_URL}/artifacts/lukso-${TARGET}.${EXT}"
 info "Tarball URL: ${UNDERLINE}${BLUE}${URL}${NO_COLOR}"
 info ""
 info "You need to agree to the LUKSO CLI terms before continuing:"


### PR DESCRIPTION
## Description

Add first step of migration by adding the google bucket deployment in addition to the gh_pages deployment.
REPO will still change in size for now.

## Manual checks

- [ ] Check that curl directly to `curl https://storage.googleapis.com/lks-lz-binaries-euw4/PR#/install.sh | sh` works

## Known issues

The repo will still grow a lot, sorry. There will be a follow up commit which completely turns off gh-pages.
