### PR TITLE
Add confirmation log when client stopped

### DIFF
--- a/cmd/lukso/start.go
+++ b/cmd/lukso/start.go
@@ -66,7 +66,7 @@ func (dependency *ClientDependency) Stop() error {
 
 	pidVal, err := pid.Load(pidLocation)
 	if err != nil {
-		log.Warnf("%s is not running - skipping...", dependency.name)
+		log.Warnf("⏭️  %s is not running - skipping...", dependency.name)
 
 		return nil
 	}
@@ -75,6 +75,8 @@ func (dependency *ClientDependency) Stop() error {
 	if err != nil {
 		return errProcessNotFound
 	}
+
+	log.Infof("🛑  Stopped %s", dependency.name)
 
 	return nil
 }


### PR DESCRIPTION
### Before:

No confirmation message
<img width="360" alt="image" src="https://user-images.githubusercontent.com/477945/230603860-0200a7e3-b91d-4be2-bef5-2f5b165f4289.png">

### After

<img width="490" alt="image" src="https://user-images.githubusercontent.com/477945/230603878-6b92088a-f806-4b3b-b194-67065881dace.png">
