### PR TITLE
Fix: No such flag

### DIFF
--- a/cmd/lukso/errors.go
+++ b/cmd/lukso/errors.go
@@ -14,7 +14,7 @@ var (
 )
 
 const (
-	noSuchFlag              = "⚠️  no such flag"
+	noSuchFlag              = "no such flag" // no emoji here - this error should match the CLI lib error - we don't throw it to user anyway
 	folderNotInitialized    = "⚠️  Folder not initialized - please make sure that you are working in an initialized directory. You can initialize the directory with the 'lukso init' command."
 	selectedClientsNotFound = "⚠️  No selected client found in LUKSO configuration file. Please make sure that you have installed your clients. You can use the install command to install clients."
 )


### PR DESCRIPTION
Quick fix for `no such flag` error message during `lukso validator import` command
