### PR TITLE
Exclude GLIBC from CLI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Build | Build
         run: |
-          env GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build \
+          env GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 go build \
               -C cmd/lukso \
               -o "$(pwd)/target/${{ matrix.target }}/release/lukso${{ matrix.bin }}" \
               -ldflags="-X 'main.Version=${{ needs.release_please.outputs.version_name }}'"


### PR DESCRIPTION
This PR excludes GLIBC from the LUKSO CLI, extending the usability across various LTS versions, including Ubuntu v20.04 and v18.04 desktop and server, and making the CLI tool leaner.

#### Development
By running the build with the `CGO_ENABLED=0` flag, it will strictly be using Go libraries.

#### Testing
Built on Mac and Linux 20.04. Now need to check the install script after CI/CD

#### Relations
Closes #88 Issue
