### PR TITLE
fix: geth v1.11.6 commit hash

### DIFF
--- a/cmd/lukso/flags.go
+++ b/cmd/lukso/flags.go
@@ -195,7 +195,7 @@ var (
 		&cli.StringFlag{
 			Name:  gethCommitHashFlag,
 			Usage: "A hash of commit that is bound to given release tag",
-			Value: "a38f4108",
+			Value: "ea9e62ca",
 		},
 	}
 	// UPDATE


### PR DESCRIPTION
The commit hash was for 1.11.5

https://geth.ethereum.org/downloads

Issue was introduced here: https://github.com/lukso-network/tools-lukso-cli/commit/73e441848d8fdbe24646c13f19ee7b9aba2f3956