### PR TITLE
Improve node up msg

### DIFF
--- a/cmd/lukso/start.go
+++ b/cmd/lukso/start.go
@@ -150,7 +150,7 @@ func startClients(ctx *cli.Context) error {
 		return cli.Exit(fmt.Sprintf("❌  There was an error while starting validator: %v", err), 1)
 	}
 
-	log.Info("🎉  Clients have been started. Your node is now 🆙.")
+	log.Info("🎉  Clients have been started. Check if your node is running correctly with 'lukso status'.")
 
 	return nil
 }


### PR DESCRIPTION
Atm, the CLI output will show "geth started" + "node is running"
But it is based on just having a successful call to geth binary. If geth exits 0.5sec later for some config error, user won't know and will think the node is up while it is not.

This is simply to change this message which can be wrong.

Current:
<img width="768" alt="image" src="https://github.com/lukso-network/tools-lukso-cli/assets/477945/5fb9bfca-93a7-4316-8eb7-d8d245345e44">

-> Misleading log messages.