### PR TITLE
Fix crash when passing password using file

### DIFF
--- a/cmd/lukso/validator.go
+++ b/cmd/lukso/validator.go
@@ -46,7 +46,7 @@ func importValidator(ctx *cli.Context) error {
 
 func startValidator(ctx *cli.Context) (err error) {
 	validatorFlags, passwordPipe, err := prepareValidatorStartFlags(ctx)
-	if passwordPipe.Name() != "" {
+	if passwordPipe != nil && passwordPipe.Name() != "" {
 		defer os.Remove(passwordPipe.Name())
 	}
 	if err != nil {


### PR DESCRIPTION
Small fix to make sure that the pipe file is both not nil and has a name.

When launching the validator with the password inside of a file the CLI was crashing, because the PasswordPipe was nil and therefore PasswordPipe.Name() was access violating instead of returning "".