### PR TITLE
fix: new Geth version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ The LUKSO CLI is able to install multiple clients for running the node.
 
 ### Client versions
 
-| Client     | Version  | Release                                                       |
-|------------|--------- |-------------------------------------------------------------- |
-| Geth       | v1.14.15 | https://github.com/ethereum/go-ethereum/releases/tag/v1.14.15 |
-| Erigon     | v2.59.3  | https://github.com/ledgerwatch/erigon/releases/tag/v2.59.3    |
-| Prysm      | v4.2.1   | https://github.com/prysmaticlabs/prysm/releases/tag/v4.2.1    |
-| Lighthouse | v5.2.0   | https://github.com/sigp/lighthouse/releases/tag/v5.2.0        |
-| Teku       | v24.4.0  | https://github.com/Consensys/teku/releases/tag/24.4.0         |
+| Client         | Version    | Release                                                       |
+|------------    |---------   |-------------------------------------------------------------- |
+| Geth           | v1.14.15   | https://github.com/ethereum/go-ethereum/releases/tag/v1.14.15 |
+| Erigon         | v2.59.3    | https://github.com/ledgerwatch/erigon/releases/tag/v2.59.3    |
+| Prysm          | v4.2.1     | https://github.com/prysmaticlabs/prysm/releases/tag/v4.2.1    |
+| Lighthouse     | v5.2.0     | https://github.com/sigp/lighthouse/releases/tag/v5.2.0        |
+| Teku           | v24.4.0    | https://github.com/Consensys/teku/releases/tag/24.4.0         |
 
 > More clients will be added in the future.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The LUKSO CLI is able to install multiple clients for running the node.
 
 | Client         | Version    | Release                                                       |
 |------------    |---------   |-------------------------------------------------------------- |
-| Geth           | v1.14.15   | https://github.com/ethereum/go-ethereum/releases/tag/v1.14.15 |
+| Geth           | v1.14.5    | https://github.com/ethereum/go-ethereum/releases/tag/v1.14.5  |
 | Erigon         | v2.59.3    | https://github.com/ledgerwatch/erigon/releases/tag/v2.59.3    |
 | Prysm          | v4.2.1     | https://github.com/prysmaticlabs/prysm/releases/tag/v4.2.1    |
 | Lighthouse     | v5.2.0     | https://github.com/sigp/lighthouse/releases/tag/v5.2.0        |
@@ -194,7 +194,7 @@ $ lukso install --geth-tag 1.13.15 --geth-commit-hash c5ba367e
 | Option                   | Description                                         | Default    |
 |--------------------------|-----------------------------------------------------|------------|
 | --agree-terms            | Automatically accept Terms and Conditions           | false      |
-| --geth-tag value         | Tag for Geth                                        | "1.14.15"  |
+| --geth-tag value         | Tag for Geth                                        | "1.14.5"   |
 | --geth-commit-hash value | A hash of commit that is bound to given release tag | "c5ba367e" |
 | --validator-tag value    | Tag for validator binary                            | "v4.2.1"   |
 | --prysm-tag value        | Tag for Prysm                                       | "v4.2.1"   |

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ The LUKSO CLI is able to install multiple clients for running the node.
 
 ### Client versions
 
-| Client     | Version | Release                                                      |
-|------------|---------|--------------------------------------------------------------|
-| Geth       | v1.14.4 | https://github.com/ethereum/go-ethereum/releases/tag/v1.14.4 |
-| Erigon     | v2.59.3 | https://github.com/ledgerwatch/erigon/releases/tag/v2.59.3   |
-| Prysm      | v4.2.1  | https://github.com/prysmaticlabs/prysm/releases/tag/v4.2.1   |
-| Lighthouse | v5.1.3  | https://github.com/sigp/lighthouse/releases/tag/v5.1.3       |
-| Teku       | v24.4.0 | https://github.com/Consensys/teku/releases/tag/24.4.0        |
+| Client     | Version  | Release                                                       |
+|------------|--------- |-------------------------------------------------------------- |
+| Geth       | v1.14.15 | https://github.com/ethereum/go-ethereum/releases/tag/v1.14.15 |
+| Erigon     | v2.59.3  | https://github.com/ledgerwatch/erigon/releases/tag/v2.59.3    |
+| Prysm      | v4.2.1   | https://github.com/prysmaticlabs/prysm/releases/tag/v4.2.1    |
+| Lighthouse | v5.2.0   | https://github.com/sigp/lighthouse/releases/tag/v5.2.0        |
+| Teku       | v24.4.0  | https://github.com/Consensys/teku/releases/tag/24.4.0         |
 
 > More clients will be added in the future.
 
@@ -194,12 +194,12 @@ $ lukso install --geth-tag 1.13.15 --geth-commit-hash c5ba367e
 | Option                   | Description                                         | Default    |
 |--------------------------|-----------------------------------------------------|------------|
 | --agree-terms            | Automatically accept Terms and Conditions           | false      |
-| --geth-tag value         | Tag for Geth                                        | "1.13.15"  |
+| --geth-tag value         | Tag for Geth                                        | "1.14.15"  |
 | --geth-commit-hash value | A hash of commit that is bound to given release tag | "c5ba367e" |
 | --validator-tag value    | Tag for validator binary                            | "v4.2.1"   |
 | --prysm-tag value        | Tag for Prysm                                       | "v4.2.1"   |
 | --erigon-tag value       | Tag for Erigon                                      | "2.59.3"   |
-| --lighthouse-tag value   | Tag for Lighthouse                                  | "v5.1.3"   |
+| --lighthouse-tag value   | Tag for Lighthouse                                  | "v5.2.0"   |
 | --teku-tag value         | Tag for Teku                                        | "24.4.0"   |
 | --help, -h               | show  help                                          | false      |
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ The LUKSO CLI is able to install multiple clients for running the node.
 
 ### Client versions
 
-| Client     | Version  | Release                                                       |
-|------------|----------|---------------------------------------------------------------|
-| Geth       | v1.13.15 | https://github.com/ethereum/go-ethereum/releases/tag/v1.13.15 |
-| Erigon     | v2.59.3  | https://github.com/ledgerwatch/erigon/releases/tag/v2.59.3    |
-| Prysm      | v4.2.1   | https://github.com/prysmaticlabs/prysm/releases/tag/v4.2.1    |
-| Lighthouse | v5.1.3   | https://github.com/sigp/lighthouse/releases/tag/v5.1.3        |
-| Teku       | v24.4.0  | https://github.com/Consensys/teku/releases/tag/24.4.0         |
+| Client     | Version | Release                                                      |
+|------------|---------|--------------------------------------------------------------|
+| Geth       | v1.14.4 | https://github.com/ethereum/go-ethereum/releases/tag/v1.14.4 |
+| Erigon     | v2.59.3 | https://github.com/ledgerwatch/erigon/releases/tag/v2.59.3   |
+| Prysm      | v4.2.1  | https://github.com/prysmaticlabs/prysm/releases/tag/v4.2.1   |
+| Lighthouse | v5.1.3  | https://github.com/sigp/lighthouse/releases/tag/v5.1.3       |
+| Teku       | v24.4.0 | https://github.com/Consensys/teku/releases/tag/24.4.0        |
 
 > More clients will be added in the future.
 

--- a/common/shared.go
+++ b/common/shared.go
@@ -4,10 +4,10 @@ const (
 	ConfigPerms   = 0750
 	SlotsPerEpoch = 32
 
-	GethTag        = "1.13.15"
+	GethTag        = "1.14.4"
 	ErigonTag      = "2.59.3"
 	PrysmTag       = "v4.2.1"
 	LighthouseTag  = "v5.1.3"
 	TekuTag        = "24.4.0"
-	GethCommitHash = "c5ba367e"
+	GethCommitHash = "5550d839"
 )

--- a/common/shared.go
+++ b/common/shared.go
@@ -4,10 +4,10 @@ const (
 	ConfigPerms   = 0750
 	SlotsPerEpoch = 32
 
-	GethTag        = "1.14.4"
+	GethTag        = "1.14.5"
 	ErigonTag      = "2.59.3"
 	PrysmTag       = "v4.2.1"
-	LighthouseTag  = "v5.1.3"
+	LighthouseTag  = "v5.2.0"
 	TekuTag        = "24.4.0"
-	GethCommitHash = "5550d839"
+	GethCommitHash = "0dd173a7"
 )


### PR DESCRIPTION
This PR updates Geth to newest suggested version: v1.14.5 - release [here.](https://github.com/ethereum/go-ethereum/releases/tag/v1.14.4)