### PR TITLE
Feat: besu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,21 @@ The LUKSO CLI is a command line tool to install, manage and set up validators of
 
 The LUKSO CLI is able to install multiple clients for running the node.
 
-- Execution Clients: [Geth](https://geth.ethereum.org/), [Erigon](https://github.com/ledgerwatch/erigon), [Nethermind](https://github.com/NethermindEth/nethermind)
+- Execution Clients: [Geth](https://geth.ethereum.org/), [Erigon](https://github.com/ledgerwatch/erigon), [Nethermind](https://github.com/NethermindEth/nethermind), [Besu](https://www.hyperledger.org/projects/besu)
 - Consensus Clients: [Prysm](https://github.com/prysmaticlabs/prysm), [Lighthouse](https://github.com/sigp/lighthouse), [Teku](https://github.com/Consensys/teku)
 - Validator Staking Clients: [Prysm](https://docs.prylabs.network/docs/how-prysm-works/prysm-validator-client), [Lighthouse](https://github.com/sigp/lighthouse), [Teku](https://github.com/Consensys/teku)
 
 ### Client versions
 
-| Client     | Version  | Release                                                            |
-|------------|----------|---------------------------------------------------------------     |
-| Geth       | v1.13.15 | https://github.com/ethereum/go-ethereum/releases/tag/v1.13.15      |
-| Erigon     | v2.59.3  | https://github.com/ledgerwatch/erigon/releases/tag/v2.59.3         |
-| Nethermind | v1.26.0  | https://github.com/NethermindEth/nethermind/releases/tag/1.26.0    |
-| Prysm      | v4.2.1   | https://github.com/prysmaticlabs/prysm/releases/tag/v4.2.1         |
-| Lighthouse | v5.1.3   | https://github.com/sigp/lighthouse/releases/tag/v5.1.3             |
-| Teku       | v24.4.0  | https://github.com/Consensys/teku/releases/tag/24.4.0              |
+| Client     | Version  | Release                                                         |
+|------------|----------|-----------------------------------------------------------------|
+| Geth       | v1.13.15 | https://github.com/ethereum/go-ethereum/releases/tag/v1.13.15   |
+| Erigon     | v2.59.3  | https://github.com/ledgerwatch/erigon/releases/tag/v2.59.3      |
+| Nethermind | v1.26.0  | https://github.com/NethermindEth/nethermind/releases/tag/1.26.0 |
+| Besu       | v24.7.0  | https://github.com/hyperledger/besu/releases/tag/24.7.0         |
+| Prysm      | v4.2.1   | https://github.com/prysmaticlabs/prysm/releases/tag/v4.2.1      |
+| Lighthouse | v5.1.3   | https://github.com/sigp/lighthouse/releases/tag/v5.1.3          |
+| Teku       | v24.4.0  | https://github.com/Consensys/teku/releases/tag/24.4.0           |
 
 > More clients will be added in the future.
 
@@ -106,6 +107,9 @@ lukso-node
 │       ├───geth                            // Config for Geth Client
 │       ├───prysm                           // Config for Prysm Client
 │       ├───erigon                          // Config for Erigon Client
+│       ├───nethermind                      // Config for Nethermind Client
+│       ├───besu                            // Config for Besu Client
+│       ├───teku                            // Config for Teku Client
 │       └───lighthouse                      // Config for Lighthouse Client
 │
 ├───[network_type]-keystore                 // Network's Validator Wallet
@@ -192,17 +196,20 @@ $ lukso install --geth-tag 1.13.15 --geth-commit-hash c5ba367e
 
 #### Options for `install`
 
-| Option                   | Description                                         | Default    |
-|--------------------------|-----------------------------------------------------|------------|
-| --agree-terms            | Automatically accept Terms and Conditions           | false      |
-| --geth-tag value         | Tag for Geth                                        | "1.13.15"  |
-| --geth-commit-hash value | A hash of commit that is bound to given release tag | "c5ba367e" |
-| --validator-tag value    | Tag for validator binary                            | "v4.2.1"   |
-| --prysm-tag value        | Tag for Prysm                                       | "v4.2.1"   |
-| --erigon-tag value       | Tag for Erigon                                      | "2.59.3"   |
-| --lighthouse-tag value   | Tag for Lighthouse                                  | "v5.1.3"   |
-| --teku-tag value         | Tag for Teku                                        | "24.4.0"   |
-| --help, -h               | show  help                                          | false      |
+| Option                         | Description                                         | Default    |
+|--------------------------------|-----------------------------------------------------|------------|
+| --agree-terms                  | Automatically accept Terms and Conditions           | false      |
+| --geth-tag value               | Tag for Geth                                        | "1.13.15"  |
+| --geth-commit-hash value       | A hash of commit that is bound to given release tag | "c5ba367e" |
+| --validator-tag value          | Tag for validator binary                            | "v4.2.1"   |
+| --prysm-tag value              | Tag for Prysm                                       | "v4.2.1"   |
+| --erigon-tag value             | Tag for Erigon                                      | "2.59.3"   |
+| --lighthouse-tag value         | Tag for Lighthouse                                  | "v5.1.3"   |
+| --teku-tag value               | Tag for Teku                                        | "24.4.0"   |
+| --besu-tag value               | Tag for Besu                                        | "24.7.0"   |
+| --nethermind-tag value         | Tag for Teku                                        | "1.26.0"   |
+| --nethermind-commit-hash value | A hash of commit that is bound to given release tag | "0068729c" |
+| --help, -h                     | show  help                                          | false      |
 
 ### `update`
 `update` will install the newest verions of the clients that you selected duing installation process.  
@@ -330,34 +337,38 @@ Please note that this won't affect your node in any way.
 
 #### Options for `start`
 
-| Option                               | Description                                                                                                                                           |
-| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **NETWORK**                          |                                                                                                                                                       |
-| --mainnet                            | Starts the LUKSO node with mainnet data [default] (./configs/mainnet)                                                                                 |
-| --testnet                            | Starts the LUKSO node with testnet data (./configs/tesnet)                                                                                            |
-| --devnet                             | Starts the LUKSO node with devnet data (./configs/devnet)                                                                                             |
-| **VALIDATOR**                        |                                                                                                                                                       |
-| --validator                          | Starts the validator client                                                                                                                           |
-| --validator-keys [string]            | Directory of the validator keys (default: "./\[network_type\]-keystore")                                                                              |
-| --validator-wallet-password [string] | Location of password file that you used for generated validator keys                                                                                  |
-| --validator-config [string]          | Path to prysms validator.yaml config file                                                                                                             |
-| --transaction-fee-recipient [string] | The address that receives block reward from transactions (required for --validator flag)                                                              |
-| --genesis-json [string]              | The path to genesis JSON file                                                                                                                         |
-| --genesis-ssz [string]               | The path to genesis SSZ file                                                                                                                          |
-| --no-slasher                         | Disables slasher                                                                                                                                      |
-| **CLIENT OPTIONS**                   |                                                                                                                                                       |
-| --logs-folder [string]               | Sets up a custom logs directory (default: "./\[network_type\]-logs")                                                                                  |
-| --geth-config [string]               | Defines the path to geth TOML config file                                                                                                             |
-| --prysm-config [string]              | Defines the path to prysm YAML config file                                                                                                            |
-| --erigon-config [string]             | Defines the path to erigon TOML config file                                                                                                           |
-| --teku-config [string]               | Defines the path to teku YAML config file                                                                                                             |
-| --validator-config [string]          | Defines the path to teku validator YAML config file                                                                                                   |
-| --geth-[command]                     | The `command` will be passed to the Geth client. [See the client docs for details](https://geth.ethereum.org/docs/fundamentals/command-line-options)  |
-| --prysm-[command]                    | The `command` will be passed to the Prysm client. [See the client docs for details](https://docs.prylabs.network/docs/prysm-usage/parameters)         |
-| --lighhouse-[command]                | The `command` will be passed to the Lighthouse client. [See the client docs for details](https://lighthouse-book.sigmaprime.io/advanced-datadir.html) |
-| --erigon-[command]                   | The `command` will be passed to the Erigon client. [See the client docs for details](https://github.com/ledgerwatch/erigon)                           |
-| --teku-[command]                     | The `command` will be passed to the Teku client. [See the client docs for details](https://github.com/ledgerwatch/erigon)                             |
-| --checkpoint-sync                    | Run a node with checkpoint sync feature                                                                                                               |
+| Option                                | Description                                                                                                                                           |
+|---------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **NETWORK**                           |                                                                                                                                                       |
+| --mainnet                             | Starts the LUKSO node with mainnet data [default] (./configs/mainnet)                                                                                 |
+| --testnet                             | Starts the LUKSO node with testnet data (./configs/tesnet)                                                                                            |
+| --devnet                              | Starts the LUKSO node with devnet data (./configs/devnet)                                                                                             |
+| **VALIDATOR**                         |                                                                                                                                                       |
+| --validator                           | Starts the validator client                                                                                                                           |
+| --validator-keys [string]             | Directory of the validator keys (default: "./\[network_type\]-keystore")                                                                              |
+| --validator-wallet-password [string]  | Location of password file that you used for generated validator keys                                                                                  |
+| --validator-config [string]           | Path to prysms validator.yaml config file                                                                                                             |
+| --transaction-fee-recipient [string]  | The address that receives block reward from transactions (required for --validator flag)                                                              |
+| --genesis-json [string]               | The path to genesis JSON file                                                                                                                         |
+| --genesis-ssz [string]                |  The path to genesis SSZ file                                                                                                                         |
+| --no-slasher                          | Disables slasher                                                                                                                                      |
+| **CLIENT OPTIONS**                    |                                                                                                                                                       |
+| --logs-folder [string]                | Sets up a custom logs directory (default: "./\[network_type\]-logs")                                                                                  |
+| --geth-config [string]                | Defines the path to geth TOML config file                                                                                                             |
+| --prysm-config [string]               | Defines the path to prysm YAML config file                                                                                                            |
+| --erigon-config [string]              | Defines the path to erigon TOML config file                                                                                                           |
+| --nethermind-config [string]          | Defines the path to nethermind CFG config file                                                                                                        |
+| --besu-config [string]                | Defines the path to besu TOML config file                                                                                                             |
+| --teku-config [string]                | Defines the path to teku YAML config file                                                                                                             | 
+| --validator-config [string]           | Defines the path to teku validator YAML config file                                                                                                   |
+| --geth-[command]                      | The `command` will be passed to the Geth client. [See the client docs for details](https://geth.ethereum.org/docs/fundamentals/command-line-options)  |
+| --prysm-[command]                     | The `command` will be passed to the Prysm client. [See the client docs for details](https://docs.prylabs.network/docs/prysm-usage/parameters)         |
+| --lighhouse-[command]                 | The `command` will be passed to the Lighthouse client. [See the client docs for details](https://lighthouse-book.sigmaprime.io/advanced-datadir.html) |
+| --erigon-[command]                    | The `command` will be passed to the Erigon client. [See the client docs for details](https://github.com/ledgerwatch/erigon)                           |
+| --teku-[command]                      | The `command` will be passed to the Teku client. [See the client docs for details](https://github.com/ledgerwatch/erigon)                             |
+| --besu-[command]                      | The `command` will be passed to the Besu client. [See the client docs for details](https://github.com/hyperledger/besu)                               |
+| --nethermind-[command]                | The `command` will be passed to the Nethermind client. [See the client docs for details](https://github.com/NethermindEth/nethermind)                 |
+| --checkpoint-sync                     | Run a node with checkpoint sync feature                                                                                                               |
 
 ### `stop`
 

--- a/commands/init.go
+++ b/commands/init.go
@@ -53,6 +53,10 @@ func InitializeDirectory(ctx *cli.Context) error {
 	_ = installConfigGroup(configs.NethermindConfigDependencies, false)
 	log.Info("✅  Nethermind configuration files downloaded!\n\n")
 
+	log.Info("⬇️  Downloading besu configuration files...")
+	_ = installConfigGroup(configs.BesuConfigDependencies, false)
+	log.Info("✅  Besu configuration files downloaded!\n\n")
+
 	log.Info("⬇️  Downloading prysm configuration files...")
 	_ = installConfigGroup(configs.PrysmConfigDependencies, false)
 	log.Info("✅  Prysm configuration files downloaded!\n\n")

--- a/commands/install.go
+++ b/commands/install.go
@@ -41,10 +41,17 @@ func InstallBinaries(ctx *cli.Context) (err error) {
 	)
 
 	consensusMessage := "\nWhich consensus client do you want to install?\n" +
-		"1: prysm\n2: lighthouse\n3: teku\n> "
+		"1: prysm\n" +
+		"2: lighthouse\n" +
+		"3: teku\n" +
+		"> "
 
 	executionMessage := "\nWhich execution client do you want to install?\n" +
-		"1: geth\n2: erigon\n3: nethermind\n> "
+		"1: geth\n" +
+		"2: erigon\n" +
+		"3: nethermind\n" +
+		"4: besu\n" +
+		"> "
 
 	consensusInput = utils.RegisterInputWithMessage(consensusMessage)
 	for consensusInput != "1" && consensusInput != "2" && consensusInput != "3" {
@@ -64,7 +71,7 @@ func InstallBinaries(ctx *cli.Context) (err error) {
 	}
 
 	executionInput = utils.RegisterInputWithMessage(executionMessage)
-	for executionInput != "1" && executionInput != "2" && executionInput != "3" {
+	for executionInput != "1" && executionInput != "2" && executionInput != "3" && executionInput != "4" {
 		executionInput = utils.RegisterInputWithMessage("Please provide a valid option\n> ")
 	}
 
@@ -77,6 +84,10 @@ func InstallBinaries(ctx *cli.Context) (err error) {
 		selectedExecution = clients.Erigon
 		executionTag = ctx.String(flags.ErigonTagFlag)
 	case "3":
+		selectedExecution = clients.Nethermind
+		executionTag = ctx.String(flags.NethermindTagFlag)
+		commitHash = ctx.String(flags.NethermindCommitHashFlag)
+	case "4":
 		selectedExecution = clients.Nethermind
 		executionTag = ctx.String(flags.NethermindTagFlag)
 		commitHash = ctx.String(flags.NethermindCommitHashFlag)

--- a/commands/install.go
+++ b/commands/install.go
@@ -88,9 +88,8 @@ func InstallBinaries(ctx *cli.Context) (err error) {
 		executionTag = ctx.String(flags.NethermindTagFlag)
 		commitHash = ctx.String(flags.NethermindCommitHashFlag)
 	case "4":
-		selectedExecution = clients.Nethermind
-		executionTag = ctx.String(flags.NethermindTagFlag)
-		commitHash = ctx.String(flags.NethermindCommitHashFlag)
+		selectedExecution = clients.Besu
+		executionTag = ctx.String(flags.BesuTagFlag)
 	}
 
 	if selectedConsensus == clients.Prysm {

--- a/commands/network.go
+++ b/commands/network.go
@@ -92,7 +92,7 @@ func updateValues(ctx *cli.Context, config networkConfig) (err error) {
 		gethTomlPath                = config.configPath + "/" + configs.GethTomlPath
 		erigonTomlPath              = config.configPath + "/" + configs.ErigonTomlPath
 		nethermindCfgPath           = config.configPath + "/" + configs.NethermindCfgPath
-		besuYamlPath                = config.configPath + "/" + configs.BesuYamlPath
+		besuTomlPath                = config.configPath + "/" + configs.BesuTomlPath
 		prysmYamlPath               = config.configPath + "/" + configs.PrysmYamlPath
 		lighthouseTomlPath          = config.configPath + "/" + configs.LighthouseTomlPath
 		lighthouseValidatorTomlPath = config.configPath + "/" + configs.LighthouseValidatorTomlPath
@@ -124,7 +124,7 @@ func updateValues(ctx *cli.Context, config networkConfig) (err error) {
 		flags.GethConfigFileFlag:                gethTomlPath,
 		flags.ErigonConfigFileFlag:              erigonTomlPath,
 		flags.NethermindConfigFileFlag:          nethermindCfgPath,
-		flags.BesuConfigFileFlag:                besuYamlPath,
+		flags.BesuConfigFileFlag:                besuTomlPath,
 		flags.PrysmConfigFileFlag:               prysmYamlPath,
 		flags.LighthouseConfigFileFlag:          lighthouseTomlPath,
 		flags.LighthouseValidatorConfigFileFlag: lighthouseValidatorTomlPath,

--- a/commands/network.go
+++ b/commands/network.go
@@ -92,6 +92,7 @@ func updateValues(ctx *cli.Context, config networkConfig) (err error) {
 		gethTomlPath                = config.configPath + "/" + configs.GethTomlPath
 		erigonTomlPath              = config.configPath + "/" + configs.ErigonTomlPath
 		nethermindCfgPath           = config.configPath + "/" + configs.NethermindCfgPath
+		besuYamlPath                = config.configPath + "/" + configs.BesuYamlPath
 		prysmYamlPath               = config.configPath + "/" + configs.PrysmYamlPath
 		lighthouseTomlPath          = config.configPath + "/" + configs.LighthouseTomlPath
 		lighthouseValidatorTomlPath = config.configPath + "/" + configs.LighthouseValidatorTomlPath
@@ -123,6 +124,7 @@ func updateValues(ctx *cli.Context, config networkConfig) (err error) {
 		flags.GethConfigFileFlag:                gethTomlPath,
 		flags.ErigonConfigFileFlag:              erigonTomlPath,
 		flags.NethermindConfigFileFlag:          nethermindCfgPath,
+		flags.BesuConfigFileFlag:                besuYamlPath,
 		flags.PrysmConfigFileFlag:               prysmYamlPath,
 		flags.LighthouseConfigFileFlag:          lighthouseTomlPath,
 		flags.LighthouseValidatorConfigFileFlag: lighthouseValidatorTomlPath,

--- a/common/shared.go
+++ b/common/shared.go
@@ -10,6 +10,7 @@ const (
 	PrysmTag             = "v4.2.1"
 	LighthouseTag        = "v5.1.3"
 	TekuTag              = "24.4.0"
+	BesuTag              = "24.4.0"
 	GethCommitHash       = "c5ba367e"
 	NethermindCommitHash = "0068729c"
 )

--- a/common/shared.go
+++ b/common/shared.go
@@ -10,7 +10,7 @@ const (
 	PrysmTag             = "v4.2.1"
 	LighthouseTag        = "v5.1.3"
 	TekuTag              = "24.4.0"
-	BesuTag              = "24.5.4"
+	BesuTag              = "24.7.0"
 	GethCommitHash       = "c5ba367e"
 	NethermindCommitHash = "0068729c"
 )

--- a/common/shared.go
+++ b/common/shared.go
@@ -10,7 +10,7 @@ const (
 	PrysmTag             = "v4.2.1"
 	LighthouseTag        = "v5.1.3"
 	TekuTag              = "24.4.0"
-	BesuTag              = "24.4.0"
+	BesuTag              = "24.5.4"
 	GethCommitHash       = "c5ba367e"
 	NethermindCommitHash = "0068729c"
 )

--- a/dependencies/clients/besu.go
+++ b/dependencies/clients/besu.go
@@ -1,0 +1,163 @@
+package clients
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/urfave/cli/v2"
+
+	"github.com/lukso-network/tools-lukso-cli/common/errors"
+	"github.com/lukso-network/tools-lukso-cli/common/system"
+	"github.com/lukso-network/tools-lukso-cli/common/utils"
+	"github.com/lukso-network/tools-lukso-cli/flags"
+	"github.com/lukso-network/tools-lukso-cli/pid"
+)
+
+const besuDepsFolder = "besu"
+
+type BesuClient struct {
+	*clientBinary
+}
+
+func NewBesuClient() *BesuClient {
+	return &BesuClient{
+		&clientBinary{
+			name:           besuDependencyName,
+			commandName:    "besu",
+			baseUrl:        "https://github.com/hyperledger/besu/releases/download/|TAG|/besu-|TAG|.tar.gz",
+			githubLocation: besuGithubLocation,
+		},
+	}
+}
+
+var Besu = NewBesuClient()
+
+var _ ClientBinaryDependency = &BesuClient{}
+
+func (b *BesuClient) PrepareStartFlags(ctx *cli.Context) (startFlags []string, err error) {
+	startFlags = b.ParseUserFlags(ctx)
+
+	startFlags = append(startFlags, fmt.Sprintf("--config-file=%s", ctx.String(flags.TekuConfigFileFlag)))
+
+	return
+}
+
+func (b *BesuClient) Install(url string, isUpdate bool) (err error) {
+	if utils.FileExists(b.FilePath()) && !isUpdate {
+		message := fmt.Sprintf("You already have the %s client installed, do you want to override your installation? [Y/n]: ", b.Name())
+		input := utils.RegisterInputWithMessage(message)
+		if !strings.EqualFold(input, "y") && input != "" {
+			log.Info("⏭️  Skipping installation...")
+
+			return nil
+		}
+	}
+
+	err = installAndExtractFromURL(url, b.name, b.FilePath(), tarFormat, isUpdate)
+	if err != nil {
+		return
+	}
+
+	_, isInstalled := os.LookupEnv(system.JavaHomeEnv) // means that JDk is not set up
+	if !isInstalled {
+		message := "Besu is written in Java. This means that to use it you need to have:\n" +
+			"- JDK installed on your computer\n" +
+			"- JAVA_HOME environment variable set\n" +
+			"Do you want to install and set up JDK along with Besu? [Y/n]\n>"
+
+		input := utils.RegisterInputWithMessage(message)
+		if !strings.EqualFold(input, "y") && input != "" {
+			log.Info("⏭️  Skipping installation...")
+
+			return
+		}
+
+		err = setupJava(isUpdate)
+		if err != nil {
+			return
+		}
+
+		permFunc := func(path string, d fs.DirEntry, err error) error {
+			return os.Chmod(path, fs.ModePerm)
+		}
+
+		err = filepath.WalkDir(tekuDepsFolder, permFunc)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func (b *BesuClient) FilePath() string {
+	return besuDepsFolder
+}
+
+func (b *BesuClient) Start(ctx *cli.Context, arguments []string) (err error) {
+	if b.IsRunning() {
+		log.Infof("🔄️  %s is already running - stopping first...", b.Name())
+
+		err = b.Stop()
+		if err != nil {
+			return
+		}
+
+		log.Infof("🛑  Stopped %s", b.Name())
+	}
+
+	command := exec.Command(fmt.Sprintf("./%s/bin/teku", b.FilePath(), tekuFolder), arguments...)
+
+	var (
+		logFile  *os.File
+		fullPath string
+	)
+
+	logFolder := ctx.String(flags.LogFolderFlag)
+	if logFolder == "" {
+		return utils.Exit(fmt.Sprintf("%v- %s", errors.ErrFlagMissing, flags.LogFolderFlag), 1)
+	}
+
+	fullPath, err = utils.PrepareTimestampedFile(logFolder, b.CommandName())
+	if err != nil {
+		return
+	}
+
+	err = os.WriteFile(fullPath, []byte{}, 0750)
+	if err != nil {
+		return
+	}
+
+	logFile, err = os.OpenFile(fullPath, os.O_RDWR, 0750)
+	if err != nil {
+		return
+	}
+
+	command.Stdout = logFile
+	command.Stderr = logFile
+
+	log.Infof("🔄  Starting %s", b.Name())
+	err = command.Start()
+	if err != nil {
+		return
+	}
+
+	pidLocation := fmt.Sprintf("%s/%s.pid", pid.FileDir, b.CommandName())
+	err = pid.Create(pidLocation, command.Process.Pid)
+
+	time.Sleep(1 * time.Second)
+
+	log.Infof("✅  %s started!", b.Name())
+
+	return
+}
+
+func (b *BesuClient) Peers(ctx *cli.Context) (outbound, inbound int, err error) {
+	return defaultExecutionPeers(ctx, 8545)
+}

--- a/dependencies/clients/besu.go
+++ b/dependencies/clients/besu.go
@@ -111,7 +111,7 @@ func (b *BesuClient) Start(ctx *cli.Context, arguments []string) (err error) {
 		log.Infof("🛑  Stopped %s", b.Name())
 	}
 
-	command := exec.Command(fmt.Sprintf("./%s/bin/teku", b.FilePath()), arguments...)
+	command := exec.Command(fmt.Sprintf("./%s/bin/besu", b.FilePath()), arguments...)
 
 	var (
 		logFile  *os.File

--- a/dependencies/clients/besu.go
+++ b/dependencies/clients/besu.go
@@ -13,13 +13,12 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/lukso-network/tools-lukso-cli/common/errors"
-	"github.com/lukso-network/tools-lukso-cli/common/system"
 	"github.com/lukso-network/tools-lukso-cli/common/utils"
 	"github.com/lukso-network/tools-lukso-cli/flags"
 	"github.com/lukso-network/tools-lukso-cli/pid"
 )
 
-const besuDepsFolder = "besu"
+const besuFolder = clientDepsFolder + "/besu"
 
 type BesuClient struct {
 	*clientBinary
@@ -59,12 +58,12 @@ func (b *BesuClient) Install(url string, isUpdate bool) (err error) {
 		}
 	}
 
-	err = installAndExtractFromURL(url, b.name, b.FilePath(), tarFormat, isUpdate)
+	err = installAndExtractFromURL(url, b.name, clientDepsFolder, tarFormat, isUpdate)
 	if err != nil {
 		return
 	}
 
-	_, isInstalled := os.LookupEnv(system.JavaHomeEnv) // means that JDk is not set up
+	isInstalled := isJdkInstalled()
 	if !isInstalled {
 		message := "Besu is written in Java. This means that to use it you need to have:\n" +
 			"- JDK installed on your computer\n" +
@@ -87,7 +86,7 @@ func (b *BesuClient) Install(url string, isUpdate bool) (err error) {
 			return os.Chmod(path, fs.ModePerm)
 		}
 
-		err = filepath.WalkDir(tekuDepsFolder, permFunc)
+		err = filepath.WalkDir(b.FilePath(), permFunc)
 		if err != nil {
 			return
 		}
@@ -97,7 +96,7 @@ func (b *BesuClient) Install(url string, isUpdate bool) (err error) {
 }
 
 func (b *BesuClient) FilePath() string {
-	return besuDepsFolder
+	return besuFolder
 }
 
 func (b *BesuClient) Start(ctx *cli.Context, arguments []string) (err error) {
@@ -112,7 +111,7 @@ func (b *BesuClient) Start(ctx *cli.Context, arguments []string) (err error) {
 		log.Infof("🛑  Stopped %s", b.Name())
 	}
 
-	command := exec.Command(fmt.Sprintf("./%s/bin/teku", b.FilePath(), tekuFolder), arguments...)
+	command := exec.Command(fmt.Sprintf("./%s/bin/teku", b.FilePath()), arguments...)
 
 	var (
 		logFile  *os.File

--- a/dependencies/clients/besu.go
+++ b/dependencies/clients/besu.go
@@ -63,6 +63,15 @@ func (b *BesuClient) Install(url string, isUpdate bool) (err error) {
 		return
 	}
 
+	permFunc := func(path string, d fs.DirEntry, err error) error {
+		return os.Chmod(path, fs.ModePerm)
+	}
+
+	err = filepath.WalkDir(b.FilePath(), permFunc)
+	if err != nil {
+		return
+	}
+
 	isInstalled := isJdkInstalled()
 	if !isInstalled {
 		message := "Besu is written in Java. This means that to use it you need to have:\n" +
@@ -78,15 +87,6 @@ func (b *BesuClient) Install(url string, isUpdate bool) (err error) {
 		}
 
 		err = setupJava(isUpdate)
-		if err != nil {
-			return
-		}
-
-		permFunc := func(path string, d fs.DirEntry, err error) error {
-			return os.Chmod(path, fs.ModePerm)
-		}
-
-		err = filepath.WalkDir(b.FilePath(), permFunc)
 		if err != nil {
 			return
 		}

--- a/dependencies/clients/besu.go
+++ b/dependencies/clients/besu.go
@@ -42,7 +42,7 @@ var _ ClientBinaryDependency = &BesuClient{}
 func (b *BesuClient) PrepareStartFlags(ctx *cli.Context) (startFlags []string, err error) {
 	startFlags = b.ParseUserFlags(ctx)
 
-	startFlags = append(startFlags, fmt.Sprintf("--config-file=%s", ctx.String(flags.TekuConfigFileFlag)))
+	startFlags = append(startFlags, fmt.Sprintf("--config-file=%s", ctx.String(flags.BesuConfigFileFlag)))
 
 	return
 }

--- a/dependencies/clients/nethermind.go
+++ b/dependencies/clients/nethermind.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	nethermindDepsFolder = "nethermind"
+	nethermindFolder = clientDepsFolder + "/nethermind"
 )
 
 type NethermindClient struct {
@@ -54,7 +54,7 @@ func (n *NethermindClient) Install(url string, isUpdate bool) (err error) {
 		}
 	}
 
-	err = installAndExtractFromURL(url, n.name, n.FilePath(), zipFormat, isUpdate)
+	err = installAndExtractFromURL(url, n.name, clientDepsFolder, zipFormat, isUpdate)
 	if err != nil {
 		return
 	}
@@ -184,5 +184,5 @@ func (n *NethermindClient) Peers(ctx *cli.Context) (outbound, inbound int, err e
 }
 
 func (n *NethermindClient) FilePath() string {
-	return nethermindDepsFolder
+	return nethermindFolder
 }

--- a/dependencies/clients/shared.go
+++ b/dependencies/clients/shared.go
@@ -659,17 +659,14 @@ func untarDir(dst string, t *tar.Reader) error {
 		case strings.Contains(header.Name, "teku-"):
 			newHeader := replaceRootFolderName(header.Name, "teku")
 			path = filepath.Join(dst, newHeader)
-			break
 
 		case strings.Contains(header.Name, "jdk-"):
 			newHeader := replaceRootFolderName(header.Name, "jdk")
 			path = filepath.Join(dst, newHeader)
-			break
 
 		case strings.Contains(header.Name, "besu-"):
 			newHeader := replaceRootFolderName(header.Name, "besu")
 			path = filepath.Join(dst, newHeader)
-			break
 
 		}
 
@@ -858,9 +855,6 @@ func isJdkInstalled() bool {
 	}
 
 	_, err := os.Stat(jdkFolder)
-	if err == nil {
-		return true
-	}
 
-	return false
+	return err == nil
 }

--- a/dependencies/clients/shared.go
+++ b/dependencies/clients/shared.go
@@ -55,6 +55,9 @@ const (
 	// distinct between zip and tar archives
 	zipFormat = "zip"
 	tarFormat = "tar"
+
+	clientDepsFolder = "clients" // folder in which client dependencies are stored
+	jdkFolder        = clientDepsFolder + "/jdk"
 )
 
 var (
@@ -653,13 +656,21 @@ func untarDir(dst string, t *tar.Reader) error {
 
 		// for the sake of compatibility with updated versions remove the tag from the tarred file - teku/teku-xx.x.x => teku/teku, same with jdk
 		switch {
-		case strings.Contains(header.Name, tekuFolder):
-			newHeader := replaceRootFolderName(header.Name, tekuFolder)
+		case strings.Contains(header.Name, "teku-"):
+			newHeader := replaceRootFolderName(header.Name, "teku")
 			path = filepath.Join(dst, newHeader)
+			break
 
-		case strings.Contains(header.Name, jdkFolder):
-			newHeader := replaceRootFolderName(header.Name, jdkFolder)
+		case strings.Contains(header.Name, "jdk-"):
+			newHeader := replaceRootFolderName(header.Name, "jdk")
 			path = filepath.Join(dst, newHeader)
+			break
+
+		case strings.Contains(header.Name, "besu-"):
+			newHeader := replaceRootFolderName(header.Name, "besu")
+			path = filepath.Join(dst, newHeader)
+			break
+
 		}
 
 		info := header.FileInfo()

--- a/dependencies/clients/shared.go
+++ b/dependencies/clients/shared.go
@@ -427,7 +427,7 @@ func (client *clientBinary) ParseUrl(tag, commitHash string) (url string) {
 }
 
 func (client *clientBinary) FilePath() string {
-	return system.UnixBinDir + "/" + client.CommandName()
+	return nethermindDepsFolder
 }
 
 func (client *clientBinary) Name() string {

--- a/dependencies/clients/shared.go
+++ b/dependencies/clients/shared.go
@@ -427,7 +427,7 @@ func (client *clientBinary) ParseUrl(tag, commitHash string) (url string) {
 }
 
 func (client *clientBinary) FilePath() string {
-	return nethermindDepsFolder
+	return system.UnixBinDir + "/" + client.CommandName()
 }
 
 func (client *clientBinary) Name() string {

--- a/dependencies/clients/shared.go
+++ b/dependencies/clients/shared.go
@@ -38,6 +38,7 @@ const (
 	tekuDependencyName                = "Teku"
 	tekuValidatorDependencyName       = "Teku Validator"
 	nethermindDependencyName          = "Nethermind"
+	besuDependencyName                = "Besu"
 
 	gethGithubLocation          = "ethereum/go-ethereum"
 	prysmaticLabsGithubLocation = "prysmaticlabs/prysm"
@@ -45,6 +46,7 @@ const (
 	erigonGithubLocation        = "ledgerwatch/erigon"
 	tekuGithubLocation          = "Consensys/teku"
 	nethermindGithubLocation    = "NethermindEth/nethermind"
+	besuGithubLocation          = "hyperledger/besu"
 
 	peerDirectionInbound  = "inbound"
 	peerDirectionOutbound = "outbound"
@@ -66,6 +68,7 @@ var (
 		tekuDependencyName:                Teku,
 		tekuValidatorDependencyName:       TekuValidator,
 		nethermindDependencyName:          Nethermind,
+		besuDependencyName:                Besu,
 	}
 
 	ClientVersions = map[string]string{
@@ -77,6 +80,7 @@ var (
 		prysmValidatorDependencyName:      common.PrysmTag,
 		lighthouseValidatorDependencyName: common.LighthouseTag,
 		tekuDependencyName:                common.TekuTag,
+		besuDependencyName:                common.BesuTag,
 	}
 )
 
@@ -833,4 +837,19 @@ func getUnameArch() (arch string) {
 	}
 
 	return
+}
+
+func isJdkInstalled() bool {
+	// JDK installed outside of the CLI
+	_, isInstalled := os.LookupEnv(system.JavaHomeEnv)
+	if isInstalled {
+		return true
+	}
+
+	_, err := os.Stat(jdkFolder)
+	if err == nil {
+		return true
+	}
+
+	return false
 }

--- a/dependencies/clients/teku.go
+++ b/dependencies/clients/teku.go
@@ -72,6 +72,15 @@ func (t *TekuClient) Install(url string, isUpdate bool) (err error) {
 		return
 	}
 
+	permFunc := func(path string, d fs.DirEntry, err error) error {
+		return os.Chmod(path, fs.ModePerm)
+	}
+
+	err = filepath.WalkDir(t.FilePath(), permFunc)
+	if err != nil {
+		return
+	}
+
 	isInstalled := isJdkInstalled()
 	if !isInstalled {
 		message := "Teku is written in Java. This means that to use it you need to have:\n" +
@@ -87,15 +96,6 @@ func (t *TekuClient) Install(url string, isUpdate bool) (err error) {
 		}
 
 		err = setupJava(isUpdate)
-		if err != nil {
-			return
-		}
-
-		permFunc := func(path string, d fs.DirEntry, err error) error {
-			return os.Chmod(path, fs.ModePerm)
-		}
-
-		err = filepath.WalkDir(t.FilePath(), permFunc)
 		if err != nil {
 			return
 		}
@@ -206,6 +206,15 @@ func setupJava(isUpdate bool) (err error) {
 	}
 
 	javaHomeVal := fmt.Sprintf("%s/%s", luksoNodeDir, jdkFolder)
+
+	permFunc := func(path string, d fs.DirEntry, err error) error {
+		return os.Chmod(path, fs.ModePerm)
+	}
+
+	err = filepath.WalkDir(jdkFolder, permFunc)
+	if err != nil {
+		return
+	}
 
 	log.Infof("⚙️  To continue working with Java clients please export the JAVA_HOME environment variable.\n"+
 		"The recommended way is to add the following line:\n\n"+

--- a/dependencies/clients/teku.go
+++ b/dependencies/clients/teku.go
@@ -20,12 +20,10 @@ import (
 )
 
 const (
-	tekuDepsFolder = "teku" // folder in which both teku and JDK are stored
-	tekuFolder     = "teku" // folder in which teku is stored (in tekuDepsFolder)
-	jdkFolder      = "jdk"  // folder in which JDK is stored (in tekuDepsFolder)
+	tekuFolder = clientDepsFolder + "/teku" // folder in which teku is stored (in tekuDepsFolder)
 
 	tekuInstallURL = "https://artifacts.consensys.net/public/teku/raw/names/teku.tar.gz/versions/|TAG|/teku-|TAG|.tar.gz"
-	jdkInstallURL  = "https://download.java.net/java/GA/jdk20.0.2/6e380f22cbe7469fa75fb448bd903d8e/9/GPL/openjdk-20.0.2_|OS|-|ARCH|_bin.tar.gz"
+	jdkInstallURL  = "https://download.java.net/java/GA/jdk22.0.1/c7ec1332f7bb44aeba2eb341ae18aca4/8/GPL/openjdk-22.0.1_|OS|-|ARCH|_bin.tar.gz"
 )
 
 type TekuClient struct {
@@ -69,12 +67,12 @@ func (t *TekuClient) Install(url string, isUpdate bool) (err error) {
 		}
 	}
 
-	err = installAndExtractFromURL(url, t.name, t.FilePath(), tarFormat, isUpdate)
+	err = installAndExtractFromURL(url, t.name, clientDepsFolder, tarFormat, isUpdate)
 	if err != nil {
 		return
 	}
 
-	_, isInstalled := os.LookupEnv(system.JavaHomeEnv) // means that JDk is not set up
+	isInstalled := isJdkInstalled()
 	if !isInstalled {
 		message := "Teku is written in Java. This means that to use it you need to have:\n" +
 			"- JDK installed on your computer\n" +
@@ -97,7 +95,7 @@ func (t *TekuClient) Install(url string, isUpdate bool) (err error) {
 			return os.Chmod(path, fs.ModePerm)
 		}
 
-		err = filepath.WalkDir(tekuDepsFolder, permFunc)
+		err = filepath.WalkDir(t.FilePath(), permFunc)
 		if err != nil {
 			return
 		}
@@ -107,7 +105,7 @@ func (t *TekuClient) Install(url string, isUpdate bool) (err error) {
 }
 
 func (t *TekuClient) FilePath() string {
-	return tekuDepsFolder
+	return tekuFolder
 }
 
 func (t *TekuClient) Start(ctx *cli.Context, arguments []string) (err error) {
@@ -122,7 +120,7 @@ func (t *TekuClient) Start(ctx *cli.Context, arguments []string) (err error) {
 		log.Infof("🛑  Stopped %s", t.Name())
 	}
 
-	command := exec.Command(fmt.Sprintf("./%s/%s/bin/teku", t.FilePath(), tekuFolder), arguments...)
+	command := exec.Command(fmt.Sprintf("./%s/bin/teku", t.FilePath()), arguments...)
 
 	var (
 		logFile  *os.File
@@ -197,7 +195,7 @@ func setupJava(isUpdate bool) (err error) {
 	jdkURL := strings.Replace(jdkInstallURL, "|OS|", systemOs, -1)
 	jdkURL = strings.Replace(jdkURL, "|ARCH|", arch, -1)
 
-	err = installAndExtractFromURL(jdkURL, "JDK", Teku.FilePath(), tarFormat, isUpdate)
+	err = installAndExtractFromURL(jdkURL, "JDK", clientDepsFolder, tarFormat, isUpdate)
 	if err != nil {
 		return err
 	}
@@ -207,7 +205,7 @@ func setupJava(isUpdate bool) (err error) {
 		return
 	}
 
-	javaHomeVal := fmt.Sprintf("%s/%s/%s", luksoNodeDir, Teku.FilePath(), jdkFolder)
+	javaHomeVal := fmt.Sprintf("%s/%s", luksoNodeDir, jdkFolder)
 
 	log.Infof("⚙️  To continue working with Java clients please export the JAVA_HOME environment variable.\n"+
 		"The recommended way is to add the following line:\n\n"+

--- a/dependencies/clients/teku.go
+++ b/dependencies/clients/teku.go
@@ -92,15 +92,15 @@ func (t *TekuClient) Install(url string, isUpdate bool) (err error) {
 		if err != nil {
 			return
 		}
-	}
 
-	permFunc := func(path string, d fs.DirEntry, err error) error {
-		return os.Chmod(path, fs.ModePerm)
-	}
+		permFunc := func(path string, d fs.DirEntry, err error) error {
+			return os.Chmod(path, fs.ModePerm)
+		}
 
-	err = filepath.WalkDir(tekuDepsFolder, permFunc)
-	if err != nil {
-		return
+		err = filepath.WalkDir(tekuDepsFolder, permFunc)
+		if err != nil {
+			return
+		}
 	}
 
 	return
@@ -209,7 +209,7 @@ func setupJava(isUpdate bool) (err error) {
 
 	javaHomeVal := fmt.Sprintf("%s/%s/%s", luksoNodeDir, Teku.FilePath(), jdkFolder)
 
-	log.Infof("⚙️  To continue working with Teku please export the JAVA_HOME environment variable.\n"+
+	log.Infof("⚙️  To continue working with Java clients please export the JAVA_HOME environment variable.\n"+
 		"The recommended way is to add the following line:\n\n"+
 		"export JAVA_HOME=%s\n\n"+
 		"To the bash startup file of your choosing (like .bashrc)", javaHomeVal)

--- a/dependencies/clients/teku_validator.go
+++ b/dependencies/clients/teku_validator.go
@@ -62,7 +62,7 @@ func (t *TekuValidatorClient) Start(ctx *cli.Context, arguments []string) (err e
 	}
 
 	arguments = append([]string{"vc"}, arguments...)
-	command := exec.Command(fmt.Sprintf("./%s/%s/bin/teku", tekuDepsFolder, tekuFolder), arguments...)
+	command := exec.Command(fmt.Sprintf("./%s/bin/teku", tekuFolder), arguments...)
 
 	var (
 		logFile  *os.File
@@ -295,7 +295,7 @@ func (t *TekuValidatorClient) Exit(ctx *cli.Context) (err error) {
 
 	args := []string{"voluntary-exit", "--validator-keys", fmt.Sprintf("%s:%s", wallet, wallet)}
 
-	exitCommand := exec.Command(fmt.Sprintf("./%s/%s/bin/teku", tekuDepsFolder, tekuFolder), args...)
+	exitCommand := exec.Command(fmt.Sprintf("./%s/bin/teku", tekuFolder), args...)
 
 	exitCommand.Stdout = os.Stdout
 	exitCommand.Stderr = os.Stderr

--- a/dependencies/configs/besu.go
+++ b/dependencies/configs/besu.go
@@ -2,13 +2,13 @@ package configs
 
 var BesuConfigDependencies = map[string]ClientConfigDependency{
 	besuMainnetConfigName: &clientConfig{
-		url:      "https://raw.githubusercontent.com/lukso-network/network-configs/main/mainnet/besu/besu.yaml",
+		url:      "https://raw.githubusercontent.com/lukso-network/network-configs/main/mainnet/besu/besu.toml",
 		name:     besuMainnetConfigName,
-		filePath: MainnetConfig + BesuYamlPath,
+		filePath: MainnetConfig + BesuTomlPath,
 	},
 	besuTestnetConfigName: &clientConfig{
-		url:      "https://raw.githubusercontent.com/lukso-network/network-configs/main/mainnet/besu/besu.yaml",
+		url:      "https://raw.githubusercontent.com/lukso-network/network-configs/main/testnet/besu/besu.toml",
 		name:     besuTestnetConfigName,
-		filePath: TestnetConfig + BesuYamlPath,
+		filePath: TestnetConfig + BesuTomlPath,
 	},
 }

--- a/dependencies/configs/besu.go
+++ b/dependencies/configs/besu.go
@@ -4,11 +4,11 @@ var BesuConfigDependencies = map[string]ClientConfigDependency{
 	besuMainnetConfigName: &clientConfig{
 		url:      "https://raw.githubusercontent.com/lukso-network/network-configs/main/mainnet/besu/besu.toml",
 		name:     besuMainnetConfigName,
-		filePath: MainnetConfig + BesuTomlPath,
+		filePath: MainnetConfig + "/" + BesuTomlPath,
 	},
 	besuTestnetConfigName: &clientConfig{
 		url:      "https://raw.githubusercontent.com/lukso-network/network-configs/main/testnet/besu/besu.toml",
 		name:     besuTestnetConfigName,
-		filePath: TestnetConfig + BesuTomlPath,
+		filePath: TestnetConfig + "/" + BesuTomlPath,
 	},
 }

--- a/dependencies/configs/besu.go
+++ b/dependencies/configs/besu.go
@@ -1,0 +1,14 @@
+package configs
+
+var BesuConfigDependencies = map[string]ClientConfigDependency{
+	besuMainnetConfigName: &clientConfig{
+		url:      "https://raw.githubusercontent.com/lukso-network/network-configs/main/mainnet/besu/besu.yaml",
+		name:     besuMainnetConfigName,
+		filePath: MainnetConfig + BesuYamlPath,
+	},
+	besuTestnetConfigName: &clientConfig{
+		url:      "https://raw.githubusercontent.com/lukso-network/network-configs/main/mainnet/besu/besu.yaml",
+		name:     besuTestnetConfigName,
+		filePath: TestnetConfig + BesuYamlPath,
+	},
+}

--- a/dependencies/configs/shared.go
+++ b/dependencies/configs/shared.go
@@ -56,6 +56,9 @@ const (
 	nethermindMainnetConfigName = "nethermind mainnet config"
 	nethermindTestnetConfigName = "nethermind testnet config"
 
+	besuMainnetConfigName = "besu mainnet config"
+	besuTestnetConfigName = "besu testnet config"
+
 	prysmMainnetConfigDependencyName = "prysm mainnet config"
 	prysmTestnetConfigDependencyName = "prysm testnet config"
 
@@ -115,6 +118,7 @@ const (
 	GethTomlPath                = "geth/geth.toml"
 	ErigonTomlPath              = "erigon/erigon.toml"
 	NethermindCfgPath           = "nethermind/nethermind.cfg"
+	BesuYamlPath                = "besu/besu.yaml"
 	PrysmYamlPath               = "prysm/prysm.yaml"
 	ValidatorYamlPath           = "prysm/validator.yaml"
 	LighthouseTomlPath          = "lighthouse/lighthouse.toml"

--- a/dependencies/configs/shared.go
+++ b/dependencies/configs/shared.go
@@ -118,7 +118,7 @@ const (
 	GethTomlPath                = "geth/geth.toml"
 	ErigonTomlPath              = "erigon/erigon.toml"
 	NethermindCfgPath           = "nethermind/nethermind.cfg"
-	BesuYamlPath                = "besu/besu.yaml"
+	BesuTomlPath                = "besu/besu.toml"
 	PrysmYamlPath               = "prysm/prysm.yaml"
 	ValidatorYamlPath           = "prysm/validator.yaml"
 	LighthouseTomlPath          = "lighthouse/lighthouse.toml"

--- a/flags/flag_names.go
+++ b/flags/flag_names.go
@@ -16,6 +16,10 @@ const (
 	NethermindConfigFileFlag = "nethermind-config"
 	NethermindDatadirFlag    = "nethermind-datadir"
 
+	BesuTagFlag        = "besu-tag"
+	BesuConfigFileFlag = "besu-config"
+	BesuDatadirFlag    = "besu-datadir"
+
 	PrysmTagFlag             = "prysm-tag"
 	GenesisStateFlag         = "genesis-ssz"
 	PrysmChainConfigFileFlag = "prysm-chain-config"

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -317,8 +317,8 @@ var (
 	BesuStartFlags = []cli.Flag{
 		&cli.StringFlag{
 			Name:  BesuConfigFileFlag,
-			Usage: "Path to besu.yaml config file",
-			Value: configs.MainnetConfig + "/" + configs.BesuYamlPath,
+			Usage: "Path to besu.toml config file",
+			Value: configs.MainnetConfig + "/" + configs.BesuTomlPath,
 		},
 		&cli.StringFlag{
 			Name:  BesuDatadirFlag,

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -15,6 +15,7 @@ func init() {
 	InstallFlags = append(InstallFlags, LighthouseDownloadFlags...)
 	InstallFlags = append(InstallFlags, TekuDownloadFlags...)
 	InstallFlags = append(InstallFlags, NethermindDownloadFlags...)
+	InstallFlags = append(InstallFlags, BesuDownloadFlags...)
 
 	StartFlags = append(StartFlags, GethStartFlags...)
 	StartFlags = append(StartFlags, ErigonStartFlags...)
@@ -24,6 +25,7 @@ func init() {
 	StartFlags = append(StartFlags, TekuStartFlags...)
 	StartFlags = append(StartFlags, NetworkFlags...)
 	StartFlags = append(StartFlags, NethermindStartFlags...)
+	StartFlags = append(StartFlags, BesuStartFlags...)
 
 	LogsFlags = append(LogsFlags, GethLogsFlags...)
 	LogsFlags = append(LogsFlags, PrysmLogsFlags...)
@@ -301,6 +303,26 @@ var (
 		&cli.StringFlag{
 			Name:  NethermindDatadirFlag,
 			Usage: "Nethermind datadir",
+			Value: configs.ExecutionMainnetDatadir,
+		},
+	}
+
+	BesuDownloadFlags = []cli.Flag{
+		&cli.StringFlag{
+			Name:  BesuTagFlag,
+			Usage: "Tag for besu",
+			Value: common.BesuTag,
+		},
+	}
+	BesuStartFlags = []cli.Flag{
+		&cli.StringFlag{
+			Name:  BesuConfigFileFlag,
+			Usage: "Path to besu.yaml config file",
+			Value: configs.MainnetConfig + "/" + configs.BesuYamlPath,
+		},
+		&cli.StringFlag{
+			Name:  BesuDatadirFlag,
+			Usage: "Besu datadir",
 			Value: configs.ExecutionMainnetDatadir,
 		},
 	}


### PR DESCRIPTION
This PR integrates `Besu` execution client in `lukso-cli` tool. This implementation runs `Besu` with https://github.com/lukso-network/network-configs in `lukso-cli`. We stick to `lukso-cli` design, where all clients use network-configs instead of built-in flag `--network=lukso`.