### PR TITLE
fix: nethermind installation destination

### DIFF
--- a/dependencies/clients/nethermind.go
+++ b/dependencies/clients/nethermind.go
@@ -54,7 +54,7 @@ func (n *NethermindClient) Install(url string, isUpdate bool) (err error) {
 		}
 	}
 
-	err = installAndExtractFromURL(url, n.name, clientDepsFolder, zipFormat, isUpdate)
+	err = installAndExtractFromURL(url, n.name, nethermindFolder, zipFormat, isUpdate)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
BUG: Nethermind is being installed into `clients` directory instead of `clients/nethermind` - this makes it unable to start, this PR fixes it