### PR TITLE
fix: Remove check for already existing db

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 🔍 Golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.56.1
+          version: v1.62.0
           args: --config=.golangci.yml
 
       - name: 🎯 Test

--- a/dependencies/clients/shared.go
+++ b/dependencies/clients/shared.go
@@ -133,12 +133,12 @@ func (client *clientBinary) Start(ctx *cli.Context, arguments []string) (err err
 		return
 	}
 
-	err = os.WriteFile(fullPath, []byte{}, 0750)
+	err = os.WriteFile(fullPath, []byte{}, 0o750)
 	if err != nil {
 		return
 	}
 
-	logFile, err = os.OpenFile(fullPath, os.O_RDWR, 0750)
+	logFile, err = os.OpenFile(fullPath, os.O_RDWR, 0o750)
 	if err != nil {
 		return
 	}
@@ -341,12 +341,6 @@ func (client *clientBinary) IsRunning() bool {
 }
 
 func initClient(ctx *cli.Context, client ClientBinaryDependency) (err error) {
-	if utils.FileExists(ctx.String(flags.GethDatadirFlag)) { // geth datadir is the same as erigon - no matter which client we use
-		log.Info("⚙️  Execution database already exists - continuing...")
-
-		return
-	}
-
 	log.Infof("⚙️  Running %s init...", client.Name())
 
 	if client.IsRunning() {


### PR DESCRIPTION
This PR provides a fix (in context of the LUKSO Mainnet dencun fork), where clients that need to initialize their db skip this process when db already exists.

Starting a node with already exising, non-dencun db:
![image](https://github.com/user-attachments/assets/33c7ae41-1a3c-450c-9961-7eb068f6f940)
![image](https://github.com/user-attachments/assets/df411e04-e9f9-4f1e-b893-a0735826becc)
