### PR TITLE
feat: Set IP for all clients during `init`

### DIFF
--- a/commands/network.go
+++ b/commands/network.go
@@ -91,7 +91,7 @@ func updateValues(ctx *cli.Context, config networkConfig) (err error) {
 		// genesisJson  = config.configPath + "/" + genesisJsonPath
 		gethTomlPath                = config.configPath + "/" + configs.GethTomlPath
 		erigonTomlPath              = config.configPath + "/" + configs.ErigonTomlPath
-		nethermindCfgPath           = config.configPath + "/" + configs.NethermindCfgPath
+		nethermindJsonPath          = config.configPath + "/" + configs.NethermindJsonPath
 		besuTomlPath                = config.configPath + "/" + configs.BesuTomlPath
 		prysmYamlPath               = config.configPath + "/" + configs.PrysmYamlPath
 		lighthouseTomlPath          = config.configPath + "/" + configs.LighthouseTomlPath
@@ -130,7 +130,7 @@ func updateValues(ctx *cli.Context, config networkConfig) (err error) {
 		flags.ValidatorKeysFlag:                 config.keysPath,
 		flags.GethConfigFileFlag:                gethTomlPath,
 		flags.ErigonConfigFileFlag:              erigonTomlPath,
-		flags.NethermindConfigFileFlag:          nethermindCfgPath,
+		flags.NethermindConfigFileFlag:          nethermindJsonPath,
 		flags.BesuConfigFileFlag:                besuTomlPath,
 		flags.PrysmConfigFileFlag:               prysmYamlPath,
 		flags.LighthouseConfigFileFlag:          lighthouseTomlPath,

--- a/dependencies/configs/nethermind.go
+++ b/dependencies/configs/nethermind.go
@@ -4,11 +4,11 @@ var NethermindConfigDependencies = map[string]ClientConfigDependency{
 	nethermindMainnetConfigName: &clientConfig{
 		url:      "https://raw.githubusercontent.com/lukso-network/network-configs/main/mainnet/nethermind/nethermind.cfg",
 		name:     nethermindMainnetConfigName,
-		filePath: MainnetConfig + "/" + NethermindCfgPath,
+		filePath: MainnetConfig + "/" + NethermindJsonPath,
 	},
 	nethermindTestnetConfigName: &clientConfig{
 		url:      "https://raw.githubusercontent.com/lukso-network/network-configs/main/testnet/nethermind/nethermind.cfg",
 		name:     nethermindTestnetConfigName,
-		filePath: TestnetConfig + "/" + NethermindCfgPath,
+		filePath: TestnetConfig + "/" + NethermindJsonPath,
 	},
 }

--- a/dependencies/configs/shared.go
+++ b/dependencies/configs/shared.go
@@ -133,7 +133,7 @@ const (
 	DepositContractBlockPath            = "shared/deposit_contract_block.txt"
 	GethTomlPath                        = "geth/geth.toml"
 	ErigonTomlPath                      = "erigon/erigon.toml"
-	NethermindCfgPath                   = "nethermind/nethermind.cfg"
+	NethermindJsonPath                  = "nethermind/nethermind.json"
 	BesuTomlPath                        = "besu/besu.toml"
 	PrysmYamlPath                       = "prysm/prysm.yaml"
 	ValidatorYamlPath                   = "prysm/validator.yaml"

--- a/flags/flags.go
+++ b/flags/flags.go
@@ -305,8 +305,8 @@ var (
 	NethermindStartFlags = []cli.Flag{
 		&cli.StringFlag{
 			Name:  NethermindConfigFileFlag,
-			Usage: "Path to nethermind.cfg config file",
-			Value: configs.MainnetConfig + "/" + configs.NethermindCfgPath,
+			Usage: "Path to nethermind.json config file",
+			Value: configs.MainnetConfig + "/" + configs.NethermindJsonPath,
 		},
 		&cli.StringFlag{
 			Name:  NethermindDatadirFlag,


### PR DESCRIPTION
This PRs provides additional clients support for populating config with public IP. 

List of IP occurences after initializing
![image](https://github.com/user-attachments/assets/11908f6a-1ce0-48e6-9bef-006f11e8a8b9)

Additionaly, while the configs were affected when writing this feature, a `nethermind.cfg` was renamed to `nethermind.json` for compatibility with config parsers (This does not affect network-configs in any way, nethermind users may need to update configs)

