### PR TITLE
fix: Pass Geth NAT option using flags, not TOML config

### DIFF
--- a/cmd/lukso-legacy/download.go
+++ b/cmd/lukso-legacy/download.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	configPerms = 0750
+	configPerms = 0o750
 	binaryPerms = int(os.ModePerm)
 )
 
@@ -256,7 +256,7 @@ func installBinaries(ctx *cli.Context) (err error) {
 		return exit(fmt.Sprintf("❌  There was an error while downloading validator: %v", err), 1)
 	}
 
-	err = cfg.Create(selectedExecution, selectedConsensus, "")
+	err = cfg.Create(selectedExecution, selectedConsensus, "", "")
 	if err != nil {
 		return exit(fmt.Sprintf("❌  There was an error while creating configration file: %v", err), 1)
 	}

--- a/cmd/lukso-legacy/init.go
+++ b/cmd/lukso-legacy/init.go
@@ -69,7 +69,7 @@ func initializeDirectory(ctx *cli.Context) error {
 	case false:
 		log.Info("⚙️   Creating LUKSO configuration file...")
 
-		err = cfg.Create("", "", "")
+		err = cfg.Create("", "", "", "")
 		if err != nil {
 			return exit(fmt.Sprintf("❌  There was an error while preparing LUKSO configuration: %v", err), 1)
 		}

--- a/cmd/lukso/main.go
+++ b/cmd/lukso/main.go
@@ -56,7 +56,7 @@ REPO: https://github.com/lukso-network/tools-lukso-cli
 			Subcommands: cli.Commands{
 				&cli.Command{
 					Name:            "configs",
-					Usage:           "Updates chain configuration files, without overwriting client configuration files",
+					Usage:           "Updates chain configuration and CLI configuration files, without overwriting client configuration files",
 					Flags:           flags.UpdateConfigFlags,
 					Action:          commands.UpdateConfigs,
 					HideHelpCommand: true,

--- a/commands/init.go
+++ b/commands/init.go
@@ -76,6 +76,7 @@ func InitializeDirectory(ctx *cli.Context) error {
 			return utils.Exit(fmt.Sprintf("❌  There was an error while preparing LUKSO configuration: %v", err), 1)
 		}
 
+		log.Infof("⚙️  IPv4 found: %s", ip)
 		log.Infof("✅  LUKSO configuration created under %s", config.Path)
 	}
 
@@ -91,8 +92,6 @@ func setIPInConfigs() (ip string, err error) {
 	if err != nil {
 		return
 	}
-
-	log.Infof("⚙️  IPv4 found: %s", ip)
 
 	type tempConfig struct {
 		path          string

--- a/commands/install.go
+++ b/commands/install.go
@@ -159,9 +159,19 @@ func InstallBinaries(ctx *cli.Context) (err error) {
 		selectedValidator = clients.Nimbus2Validator
 	}
 
-	err = cfg.Create(selectedExecution.Name(), selectedConsensus.Name(), selectedValidator.Name())
+	err = cfg.WriteExecution(selectedExecution.Name())
 	if err != nil {
-		return utils.Exit(fmt.Sprintf("❌  There was an error while creating configration file: %v", err), 1)
+		return utils.Exit(fmt.Sprintf("❌  There was an error while writing execution client: %v", err), 1)
+	}
+
+	err = cfg.WriteConsensus(selectedConsensus.Name())
+	if err != nil {
+		return utils.Exit(fmt.Sprintf("❌  There was an error while writing consensus client: %v", err), 1)
+	}
+
+	err = cfg.WriteValidator(selectedValidator.Name())
+	if err != nil {
+		return utils.Exit(fmt.Sprintf("❌  There was an error while writing validator client: %v", err), 1)
 	}
 
 	log.Info("✅  Configuration files created!")

--- a/commands/start.go
+++ b/commands/start.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -26,6 +27,9 @@ func StartClients(ctx *cli.Context) (err error) {
 	if err != nil {
 		return utils.Exit(fmt.Sprintf("❌  Couldn't read from config file: %v", err), 1)
 	}
+
+	// Pass down the IP to any client that needs to set it in flag
+	ctx.Context = context.WithValue(ctx.Context, "ip", cfg.IPv4())
 
 	selectedExecution := cfg.Execution()
 	selectedConsensus := cfg.Consensus()

--- a/commands/start.go
+++ b/commands/start.go
@@ -10,6 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 
+	"github.com/lukso-network/tools-lukso-cli/common"
 	"github.com/lukso-network/tools-lukso-cli/common/errors"
 	"github.com/lukso-network/tools-lukso-cli/common/network"
 	"github.com/lukso-network/tools-lukso-cli/common/utils"
@@ -29,7 +30,7 @@ func StartClients(ctx *cli.Context) (err error) {
 	}
 
 	// Pass down the IP to any client that needs to set it in flag
-	ctx.Context = context.WithValue(ctx.Context, "ip", cfg.IPv4())
+	ctx.Context = context.WithValue(ctx.Context, common.ConfigKey("ip"), cfg.IPv4())
 
 	selectedExecution := cfg.Execution()
 	selectedConsensus := cfg.Consensus()

--- a/commands/update.go
+++ b/commands/update.go
@@ -69,6 +69,18 @@ func UpdateConfigs(ctx *cli.Context) (err error) {
 		return cli.Exit(errors.FolderNotInitialized, 1)
 	}
 
+	log.Info("⬇️  Updating IPv4 Addres...")
+
+	ip, err := getPublicIP()
+	if err != nil {
+		log.Warn("⚠️  There was an error while getting the IPv4 Address: continuing...")
+	} else {
+		err = cfg.WriteIPv4(ip)
+		if err != nil {
+			return utils.Exit(fmt.Sprintf("❌  There was an error while writing IPv4 Address: %v", err), 1)
+		}
+	}
+
 	if ctx.Bool(flags.AllFlag) {
 		message := "⚠️  Warning - this action will overwrite all of your client configuration files, are you sure you want to continue? [y/N]\n> "
 

--- a/common/ctxkeys.go
+++ b/common/ctxkeys.go
@@ -1,0 +1,4 @@
+package common
+
+// ConfigKey is a string alias, used for distincting between different key types
+type ConfigKey string

--- a/config/config.go
+++ b/config/config.go
@@ -62,12 +62,12 @@ type Config struct {
 }
 
 type configValues struct {
-	useClients struct {
-		executionClient string `mapstructure:"execution"`
-		consensusClient string `mapstructure:"consensus"`
-		validatorClient string `mapstructure:"validator"`
+	UseClients struct {
+		ExecutionClient string `mapstructure:"execution"`
+		ConsensusClient string `mapstructure:"consensus"`
+		ValidatorClient string `mapstructure:"validator"`
 	} `mapstructure:"useclients"`
-	ipv4 string `mapstructure:"ipv4"`
+	Ipv4 string `mapstructure:"ipv4"`
 }
 
 // NewConfig creates and initializes viper config instance - it doesn't load config, to load use c.Read().
@@ -170,19 +170,19 @@ func (c *Config) Read() (err error) {
 }
 
 func (c *Config) Execution() string {
-	return c.useClients.executionClient
+	return c.UseClients.ExecutionClient
 }
 
 func (c *Config) Consensus() string {
-	return c.useClients.consensusClient
+	return c.UseClients.ConsensusClient
 }
 
 func (c *Config) Validator() string {
-	return c.useClients.validatorClient
+	return c.UseClients.ValidatorClient
 }
 
 func (c *Config) IPv4() string {
-	ip := c.ipv4
+	ip := c.Ipv4
 	if ip == "" {
 		ip = "0.0.0.0"
 	}

--- a/dependencies/clients/geth.go
+++ b/dependencies/clients/geth.go
@@ -67,7 +67,7 @@ func (g *GethClient) PrepareStartFlags(ctx *cli.Context) (startFlags []string, e
 		return
 	}
 
-	ip := ctx.Context.Value("ip")
+	ip := ctx.Context.Value(common.ConfigKey("ip"))
 
 	startFlags = g.ParseUserFlags(ctx)
 	startFlags = append(startFlags, fmt.Sprintf("--config=%s", ctx.String(flags.GethConfigFileFlag)))

--- a/dependencies/clients/geth.go
+++ b/dependencies/clients/geth.go
@@ -67,9 +67,11 @@ func (g *GethClient) PrepareStartFlags(ctx *cli.Context) (startFlags []string, e
 		return
 	}
 
+	ip := ctx.Context.Value("ip")
+
 	startFlags = g.ParseUserFlags(ctx)
 	startFlags = append(startFlags, fmt.Sprintf("--config=%s", ctx.String(flags.GethConfigFileFlag)))
-
+	startFlags = append(startFlags, fmt.Sprintf("--nat=extip:%s", ip))
 	return
 }
 


### PR DESCRIPTION
This PR passes geth's NAT option to runtime flags instead of config file. It fixes the way viper handles config formatting