### PR TITLE
fix: Update of clients inside the `clients` directory

### DIFF
--- a/commands/update.go
+++ b/commands/update.go
@@ -47,7 +47,7 @@ func UpdateClients(ctx *cli.Context) (err error) {
 	toUpdate := []clients.ClientBinaryDependency{execution, consensus, validator}
 
 	for _, client := range toUpdate {
-		if client == clients.LighthouseValidator || client == clients.TekuValidator {
+		if client == clients.LighthouseValidator || client == clients.TekuValidator || client == clients.Nimbus2Validator {
 			continue
 		}
 

--- a/dependencies/clients/besu.go
+++ b/dependencies/clients/besu.go
@@ -96,6 +96,16 @@ func (b *BesuClient) Install(url string, isUpdate bool) (err error) {
 	return
 }
 
+func (b *BesuClient) Update() (err error) {
+	tag := b.getVersion()
+
+	log.WithField("dependencyTag", tag).Infof("⬇️  Updating %s", b.name)
+
+	url := b.ParseUrl(tag, "")
+
+	return b.Install(url, true)
+}
+
 func (b *BesuClient) FilePath() string {
 	return besuFolder
 }

--- a/dependencies/clients/erigon.go
+++ b/dependencies/clients/erigon.go
@@ -135,6 +135,16 @@ func (e *ErigonClient) Install(url string, isUpdate bool) (err error) {
 	return
 }
 
+func (e *ErigonClient) Update() (err error) {
+	tag := e.getVersion()
+
+	log.WithField("dependencyTag", tag).Infof("⬇️  Updating %s", e.name)
+
+	url := e.ParseUrl(tag, "")
+
+	return e.Install(url, true)
+}
+
 func (e *ErigonClient) PrepareStartFlags(ctx *cli.Context) (startFlags []string, err error) {
 	if !utils.FlagFileExists(ctx, flags.ErigonConfigFileFlag) {
 		err = errors.ErrFlagMissing

--- a/dependencies/clients/nimbus2.go
+++ b/dependencies/clients/nimbus2.go
@@ -111,6 +111,16 @@ func (n *Nimbus2Client) Install(url string, isUpdate bool) (err error) {
 	return
 }
 
+func (n *Nimbus2Client) Update() (err error) {
+	tag := n.getVersion()
+
+	log.WithField("dependencyTag", tag).Infof("⬇️  Updating %s", n.name)
+
+	url := n.ParseUrl(tag, common.Nimbus2CommitHash)
+
+	return n.Install(url, true)
+}
+
 func (n *Nimbus2Client) FilePath() string {
 	return nimbus2Folder
 }

--- a/dependencies/clients/teku.go
+++ b/dependencies/clients/teku.go
@@ -105,6 +105,16 @@ func (t *TekuClient) Install(url string, isUpdate bool) (err error) {
 	return
 }
 
+func (t *TekuClient) Update() (err error) {
+	tag := t.getVersion()
+
+	log.WithField("dependencyTag", tag).Infof("⬇️  Updating %s", t.name)
+
+	url := t.ParseUrl(tag, "")
+
+	return t.Install(url, true)
+}
+
 func (t *TekuClient) FilePath() string {
 	return tekuFolder
 }


### PR DESCRIPTION
This PR fixes a bug where clients inside the `clients` directory were not updated correctly.
The clients that are unaffected are:
- Geth
- Prysm
- Lighthouse