### PR TITLE
fix: Nethermind update broken link

### DIFF
--- a/dependencies/clients/nethermind.go
+++ b/dependencies/clients/nethermind.go
@@ -161,7 +161,7 @@ func (n *NethermindClient) Update() (err error) {
 
 	// this commit hash is hardcoded, but since update should only be responsible for updating the client to
 	// LUKSO supported version this is fine.
-	url := n.ParseUrl(tag, common.GethCommitHash)
+	url := n.ParseUrl(tag, common.NethermindCommitHash)
 
 	return n.Install(url, true)
 }


### PR DESCRIPTION
This PR fixes an issue where users are unable to correctly update Nethermind client